### PR TITLE
Support ESM JS module imports for custom UI extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,12 @@
     "@splunk/splunk-utils": "^2.0.0",
     "@splunk/themes": "^0.7.0",
     "axios": "^0.21.1",
-    "jsonschema": "^1.4.0",
     "immutability-helper": "^3.1.1",
+    "jsonschema": "^1.4.0",
     "react": "^16.12.0",
-    "styled-components": "^5.1.1",
-    "react-router-dom": "^5.2.0",
     "react-dom": "^16.12.0",
+    "react-router-dom": "^5.2.0",
+    "styled-components": "^5.1.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {
@@ -41,13 +41,13 @@
     "@splunk/babel-preset": "^3.0.0",
     "@splunk/eslint-config": "^4.0.0",
     "@splunk/stylelint-config": "^4.0.0",
-    "postcss": "^8.2.10",
     "@splunk/webpack-configs": "^5.0.0",
     "babel-eslint": "^10.1.0",
     "babel-loader": "^8.0.4",
     "chai": "^3.5.0",
     "copy-webpack-plugin": "^4.5.2",
     "cross-env": "^7.0.3",
+    "css-loader": "^5.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^7.14.0",
@@ -59,14 +59,14 @@
     "eslint-plugin-react": "^7.21.5",
     "eslint-plugin-react-hooks": "^4.2.0",
     "html-webpack-plugin": "^3.2.0",
+    "postcss": "^8.2.10",
     "prettier": "^2.0.5",
     "semantic-release": "^17.4.2",
+    "style-loader": "^2.0.0",
     "stylelint": "^13.0.0",
     "webpack": "^4.16.2",
     "webpack-cli": "^3.1.0",
-    "webpack-merge": "^4.1.3",
-    "css-loader": "^5.2.0",
-    "style-loader": "^2.0.0"
+    "webpack-merge": "^4.1.3"
   },
   "engines": {
     "node": ">=6"

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -14,6 +14,7 @@ import { MODE_CLONE, MODE_CREATE, MODE_EDIT, MODE_CONFIG } from '../constants/mo
 import { PAGE_INPUT, PAGE_CONF } from '../constants/pages';
 import { axiosCallWrapper } from '../util/axiosCallWrapper';
 import { parseErrorMsg, getFormattedMessage } from '../util/messageUtil';
+import { getBuildDirPath } from '../util/script';
 
 import {
     ERROR_REQUEST_TIMEOUT_TRY_AGAIN,
@@ -734,17 +735,20 @@ class BaseFormView extends PureComponent {
 
     // generatesubmitMessage
     loadHook = (module, globalConfig) => {
-        const myPromise = new Promise((myResolve) => {
-            __non_webpack_require__([`app/${this.appName}/js/build/custom/${module}`], (Hook) => {
-                this.hook = new Hook(
-                    globalConfig,
-                    this.props.serviceName,
-                    this.state,
-                    this.props.mode,
-                    this.util
-                );
-                myResolve(Hook);
-            });
+        const myPromise = new Promise((resolve) => {
+            import(/* webpackIgnore: true */ `${getBuildDirPath()}/custom/${module}.js`).then(
+                (external) => {
+                    const Hook = external.default;
+                    this.hook = new Hook(
+                        globalConfig,
+                        this.props.serviceName,
+                        this.state,
+                        this.props.mode,
+                        this.util
+                    );
+                    resolve(Hook);
+                }
+            );
         });
         return myPromise;
     };

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -341,8 +341,12 @@ class BaseFormView extends PureComponent {
         if (this.hookDeferred) {
             this.hookDeferred.then(() => {
                 if (typeof this.hook.onCreate === 'function') {
-                    // TODO: try catch to stop UI break
-                    this.hook.onCreate();
+                    try {
+                        this.hook.onCreate();
+                    } catch (err) {
+                        // eslint-disable-next-line no-console
+                        console.error(err);
+                    }
                 }
             });
         }

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -955,6 +955,7 @@ class BaseFormView extends PureComponent {
                         try {
                             this.hook.onRender();
                         } catch (err) {
+                            // eslint-disable-next-line no-console
                             console.error(err);
                         }
                     }
@@ -968,6 +969,7 @@ class BaseFormView extends PureComponent {
                             try {
                                 this.hook.onEditLoad();
                             } catch (err) {
+                                // eslint-disable-next-line no-console
                                 console.error(err);
                             }
                         }

--- a/src/main/webapp/components/CustomControl.jsx
+++ b/src/main/webapp/components/CustomControl.jsx
@@ -16,8 +16,13 @@ class CustomControl extends Component {
 
     componentDidMount() {
         const globalConfig = getUnifiedConfigs();
+        const appName = globalConfig.meta.name;
 
-        this.loadCustomControl(this.props.controlOptions.src).then((Control) => {
+        this.loadCustomControl(
+            this.props.controlOptions.src,
+            this.props.controlOptions.type,
+            appName
+        ).then((Control) => {
             const customControl = new Control(
                 globalConfig,
                 this.el,
@@ -42,16 +47,21 @@ class CustomControl extends Component {
         return false;
     }
 
-    loadCustomControl = (module) => {
-        const myPromise = new Promise((resolve) => {
-            import(/* webpackIgnore: true */ `${getBuildDirPath()}/custom/${module}.js`).then(
-                (external) => {
-                    const Control = external.default;
+    loadCustomControl = (module, type, appName) => {
+        return new Promise((resolve) => {
+            if (type === 'external') {
+                import(/* webpackIgnore: true */ `${getBuildDirPath()}/custom/${module}.js`).then(
+                    (external) => {
+                        const Control = external.default;
+                        resolve(Control);
+                    }
+                );
+            } else {
+                __non_webpack_require__([`app/${appName}/js/build/custom/${module}`], (Control) => {
                     resolve(Control);
-                }
-            );
+                });
+            }
         });
-        return myPromise;
     };
 
     setValue = (newValue) => {

--- a/src/main/webapp/components/CustomControl.jsx
+++ b/src/main/webapp/components/CustomControl.jsx
@@ -73,7 +73,7 @@ class CustomControl extends Component {
             <>
                 {this.state.loading && _('Loading...')}
                 {
-                    <span
+                    <span // nosemgrep: typescript.react.security.audit.react-no-refs.react-no-refs
                         ref={(el) => {
                             this.el = el;
                         }}

--- a/src/main/webapp/components/CustomMenu.jsx
+++ b/src/main/webapp/components/CustomMenu.jsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { _ } from '@splunk/ui-utils/i18n';
 import { getUnifiedConfigs } from '../util/util';
+import { getBuildDirPath } from '../util/script';
 
 class CustomMenu extends Component {
     constructor(props) {
@@ -38,10 +39,12 @@ class CustomMenu extends Component {
         const globalConfig = getUnifiedConfigs();
         const appName = globalConfig.meta.name;
         return new Promise((resolve) => {
-            __non_webpack_require__(
-                [`app/${appName}/js/build/custom/${this.props.fileName}`],
-                (Control) => resolve(Control)
-            );
+            import(
+                /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${this.props.fileName}.js`
+            ).then((external) => {
+                const Control = external.default;
+                resolve(Control);
+            });
         });
     };
 

--- a/src/main/webapp/components/CustomMenu.jsx
+++ b/src/main/webapp/components/CustomMenu.jsx
@@ -36,15 +36,24 @@ class CustomMenu extends Component {
     };
 
     loadCustomMenu = () => {
-        const globalConfig = getUnifiedConfigs();
-        const appName = globalConfig.meta.name;
         return new Promise((resolve) => {
-            import(
-                /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${this.props.fileName}.js`
-            ).then((external) => {
-                const Control = external.default;
-                resolve(Control);
-            });
+            if (this.props.type === 'external') {
+                import(
+                    /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${
+                        this.props.fileName
+                    }.js`
+                ).then((external) => {
+                    const Control = external.default;
+                    resolve(Control);
+                });
+            } else {
+                const globalConfig = getUnifiedConfigs();
+                const appName = globalConfig.meta.name;
+                __non_webpack_require__(
+                    [`app/${appName}/js/build/custom/${this.props.fileName}`],
+                    (Control) => resolve(Control)
+                );
+            }
         });
     };
 
@@ -67,6 +76,7 @@ class CustomMenu extends Component {
 
 CustomMenu.propTypes = {
     fileName: PropTypes.string.isRequired,
+    type: PropTypes.string,
     handleChange: PropTypes.func,
 };
 

--- a/src/main/webapp/components/table/CustomTableControl.jsx
+++ b/src/main/webapp/components/table/CustomTableControl.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { _ } from '@splunk/ui-utils/i18n';
 
 import { getUnifiedConfigs } from '../../util/util';
+import { getBuildDirPath } from '../../util/script';
 
 class CustomTableControl extends Component {
     constructor(props) {
@@ -40,13 +41,13 @@ class CustomTableControl extends Component {
     }
 
     loadCustomControl = () => {
-        const globalConfig = getUnifiedConfigs();
-        const appName = globalConfig.meta.name;
         return new Promise((resolve) => {
-            __non_webpack_require__(
-                [`app/${appName}/js/build/custom/${this.props.fileName}`],
-                (Control) => resolve(Control)
-            );
+            import(
+                /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${this.props.fileName}.js`
+            ).then((external) => {
+                const Control = external.default;
+                resolve(Control);
+            });
         });
     };
 

--- a/src/main/webapp/components/table/CustomTableControl.jsx
+++ b/src/main/webapp/components/table/CustomTableControl.jsx
@@ -42,18 +42,33 @@ class CustomTableControl extends Component {
 
     loadCustomControl = () => {
         return new Promise((resolve) => {
-            import(
-                /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${this.props.fileName}.js`
-            ).then((external) => {
-                const Control = external.default;
-                resolve(Control);
-            });
+            if (this.props.type === 'external') {
+                import(
+                    /* webpackIgnore: true */ `${getBuildDirPath()}/custom/${
+                        this.props.fileName
+                    }.js`
+                ).then((external) => {
+                    const Control = external.default;
+                    resolve(Control);
+                });
+            } else {
+                const globalConfig = getUnifiedConfigs();
+                const appName = globalConfig.meta.name;
+                __non_webpack_require__(
+                    [`app/${appName}/js/build/custom/${this.props.fileName}`],
+                    (Control) => resolve(Control)
+                );
+            }
         });
     };
 
     render() {
         if (!this.state.loading) {
-            this.customControl.render(this.props.row, this.props.field);
+            try {
+                this.customControl.render(this.props.row, this.props.field);
+            } catch (err) {
+                console.error(err);
+            }
         }
         return (
             <>
@@ -76,6 +91,7 @@ CustomTableControl.propTypes = {
     row: PropTypes.object.isRequired,
     field: PropTypes.string,
     fileName: PropTypes.string.isRequired,
+    type: PropTypes.string,
 };
 
 export default CustomTableControl;

--- a/src/main/webapp/components/table/CustomTableControl.jsx
+++ b/src/main/webapp/components/table/CustomTableControl.jsx
@@ -67,6 +67,7 @@ class CustomTableControl extends Component {
             try {
                 this.customControl.render(this.props.row, this.props.field);
             } catch (err) {
+                // eslint-disable-next-line no-console
                 console.error(err);
             }
         }

--- a/src/main/webapp/components/table/CustomTableRow.jsx
+++ b/src/main/webapp/components/table/CustomTableRow.jsx
@@ -45,6 +45,7 @@ function CustomTableRow(props) {
             field: header.field,
             row: customRow,
             fileName: header.customCell.src,
+            type: header.customCell.type,
         });
     };
 

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -230,6 +230,7 @@ function InputPage() {
                                 <ColumnLayout.Column span={3} className="input_button">
                                     {React.createElement(CustomMenu, {
                                         fileName: customMenuField.src,
+                                        type: customMenuField.type,
                                         handleChange: changeRoute,
                                     })}
                                 </ColumnLayout.Column>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,5 +28,5 @@ module.exports = webpackMerge(baseConfig, {
             },
         ]),
     ],
-    devtool: 'eval-source-map',
+    devtool: 'inline-source-map',
 });


### PR DESCRIPTION
Jira: https://jira.splunk.com/browse/ADDON-37161

Changes:

- Added `{type: "external"}` param support for custom UI extensions (i.e. hook, cell, control, menu, row) in globalConfig to support ESM JS modules (Note: when no type is specified, it will default to requireJS import which was the old way) 
- Added error handling in custom UI extensions so that it does not crash the whole UI in case of any error in the extensions

For details on ESM modules: https://webpack.js.org/guides/ecma-script-modules/