### PR TITLE
fix: add `schema.json` and NOTICE in release tarball

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "eslint src --ext \".js,.jsx\"",
     "eslint:ci": "yarn run eslint -f junit -o test-reports/lint-results.xml",
     "eslint:fix": "eslint src --ext \".js, .jsx\" --fix",
-    "link:app": "ln -s $PWD/dist $SPLUNK_HOME/etc/apps/my-splunk-app",
+    "link:app": "ln -s $PWD/dist/package_resources $SPLUNK_HOME/etc/apps/my-splunk-app",
     "lint": "yarn run eslint && yarn run stylelint",
     "lint:ci": "yarn run eslint:ci && yarn run stylelint",
     "start": "webpack --watch",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "eslint": "eslint src --ext \".js,.jsx\"",
     "eslint:ci": "yarn run eslint -f junit -o test-reports/lint-results.xml",
     "eslint:fix": "eslint src --ext \".js, .jsx\" --fix",
-    "link:app": "ln -s $PWD/dist/package_resources $SPLUNK_HOME/etc/apps/my-splunk-app",
+    "link:app": "ln -s $PWD/dist/package $SPLUNK_HOME/etc/apps/my-splunk-app",
     "lint": "yarn run eslint && yarn run stylelint",
     "lint:ci": "yarn run eslint:ci && yarn run stylelint",
     "start": "webpack --watch",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,14 +2,14 @@ const path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const webpackMerge = require('webpack-merge');
 const baseConfig = require('@splunk/webpack-configs/base.config').default;
-const LicenseWebpackPlugin = require('license-webpack-plugin').LicenseWebpackPlugin;
+const { LicenseWebpackPlugin } = require('license-webpack-plugin');
 
 module.exports = webpackMerge(baseConfig, {
     entry: {
         entry_page: path.join(__dirname, 'src/main/webapp/pages/entry_page'),
     },
     output: {
-        path: path.join(__dirname, 'dist/appserver/static/js/build'),
+        path: path.join(__dirname, 'dist/package_resources/appserver/static/js/build'),
         filename: '[name].js',
         chunkFilename: '[name].js',
     },
@@ -26,7 +26,11 @@ module.exports = webpackMerge(baseConfig, {
         new CopyWebpackPlugin([
             {
                 from: path.join(__dirname, 'src/main/resources/splunk'),
-                to: path.join(__dirname, 'dist'),
+                to: path.join(__dirname, 'dist/package_resources'),
+            },
+            {
+                from: path.join(__dirname, 'src/main/webapp/schema/schema.json'),
+                to: path.join(__dirname, 'dist/schema'),
             },
         ]),
     ],

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,7 @@ module.exports = webpackMerge(baseConfig, {
         entry_page: path.join(__dirname, 'src/main/webapp/pages/entry_page'),
     },
     output: {
-        path: path.join(__dirname, 'dist/package_resources/appserver/static/js/build'),
+        path: path.join(__dirname, 'dist/package/appserver/static/js/build'),
         filename: '[name].js',
         chunkFilename: '[name].js',
     },
@@ -26,7 +26,7 @@ module.exports = webpackMerge(baseConfig, {
         new CopyWebpackPlugin([
             {
                 from: path.join(__dirname, 'src/main/resources/splunk'),
-                to: path.join(__dirname, 'dist/package_resources'),
+                to: path.join(__dirname, 'dist/package'),
             },
             {
                 from: path.join(__dirname, 'src/main/webapp/schema/schema.json'),


### PR DESCRIPTION
Bundle `schema.json` and `THIRDPARTY.npm` (notice) along with generated static files for `ucc-gen` to consume.

![image](https://user-images.githubusercontent.com/70878308/120103765-e192f500-c16e-11eb-95a5-b3c82366ca81.png)

Note: `license-check` CI should pass after merging: https://github.com/splunk/addonfactory-ucc-base-ui/pull/32