### PR TITLE
fix: keep only one way routing as done in ucc < 5

### DIFF
--- a/THIRDPARTY.npm
+++ b/THIRDPARTY.npm
@@ -17631,6 +17631,7 @@ Copyright (c) Microsoft Corporation.
 ** @types/minimist; version 1.2.1 -- 
 Copyright (c) Microsoft Corporation.
 ** @types/node; version 15.6.1 -- 
+Copyright (c) Microsoft Corporation.
 ** @types/normalize-package-data; version 2.4.0 -- 
 Copyright (c) Microsoft Corporation.
 ** @types/parse-json; version 4.0.0 -- 
@@ -19005,6 +19006,7 @@ Copyright (c) 2014-present Nicolo Ribaudo and other contributors
 ** babel-plugin-polyfill-corejs2; version 0.2.0 -- https://github.com/babel/babel-polyfills#readme
 Copyright (c) 2014-present Nicolo Ribaudo and other contributors
 ** babel-plugin-polyfill-corejs3; version 0.2.0 -- https://github.com/babel/babel-polyfills#readme
+Copyright (c) 2014-present Nicolo Ribaudo and other contributors
 ** babel-plugin-polyfill-regenerator; version 0.2.0 -- https://github.com/babel/babel-polyfills#readme
 
 MIT License
@@ -20579,6 +20581,7 @@ Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 (c) Sindre Sorhus (https://sindresorhus.com)
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 ** p-retry; version 4.5.0 -- https://github.com/sindresorhus/p-retry#readme
+Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
 ** parent-module; version 1.0.1 -- https://github.com/sindresorhus/parent-module#readme
 (c) Sindre Sorhus (https://sindresorhus.com)
 Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)

--- a/src/main/webapp/components/table/CustomTable.jsx
+++ b/src/main/webapp/components/table/CustomTable.jsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, memo, useState, useContext } from 'react';
-import { useHistory } from 'react-router-dom';
 import PropTypes from 'prop-types';
 
 import Table from '@splunk/react-ui/Table';
@@ -51,7 +50,6 @@ function CustomTable({
         serviceToStyleMap[x.name] = x.style === STYLE_PAGE ? STYLE_PAGE : STYLE_MODAL;
     });
 
-    const history = useHistory();
     const query = useQuery();
 
     // Run only once when component is mounted to load component based on initial query params
@@ -80,21 +78,12 @@ function CustomTable({
                 // useEffect dependency which will only be changed in case of editing entity
                 setEntityModal({ ...entityModal, open: false });
             }
-        } else if (query.get('tab') !== serviceName && query.get('record')) {
-            // remove the record param in case of wrong tab
-            query.delete('record');
-            history.push({ search: query.toString() });
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [history.location.search]);
+    }, []);
 
     const handleEntityClose = () => {
         setEntityModal({ ...entityModal, open: false });
-        // remove query param and push to browser history only when mode is edit
-        if (entityModal.mode === MODE_EDIT) {
-            query.delete('record');
-            history.push({ search: query.toString() });
-        }
     };
 
     const handleEditActionClick = useCallback(
@@ -109,13 +98,10 @@ function CustomTable({
                     stanzaName: selectedRow.name,
                     mode: MODE_EDIT,
                 });
-                // set query and push to history
-                query.set('record', selectedRow.name);
-                history.push({ search: query.toString() });
             }
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [entityModal, history.location.search]
+        [entityModal]
     );
 
     const handleDeleteClose = () => {

--- a/src/main/webapp/pages/Configuration/ConfigurationPage.jsx
+++ b/src/main/webapp/pages/Configuration/ConfigurationPage.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback, useEffect } from 'react';
-import { useHistory } from 'react-router-dom';
 
 import { _ } from '@splunk/ui-utils/i18n';
 import TabBar from '@splunk/react-ui/TabBar';
@@ -35,7 +34,6 @@ function ConfigurationPage() {
 
     const [activeTabId, setActiveTabId] = useState(tabs[0].name);
 
-    const history = useHistory();
     const query = useQuery();
 
     // Run initially and when query is updated to set active tab based on initial URL
@@ -51,22 +49,11 @@ function ConfigurationPage() {
             setActiveTabId(query.get('tab'));
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [history.location.search]);
-
-    // Run only once to set initial default tab query param
-    useEffect(() => {
-        if (!query.get('tab')) {
-            query.set('tab', activeTabId);
-            history.push({ search: query.toString() });
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const handleChange = useCallback(
         (e, { selectedTabId }) => {
             setActiveTabId(selectedTabId);
-            query.set('tab', selectedTabId);
-            history.push({ search: query.toString() });
         },
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [activeTabId]


### PR DESCRIPTION
**Jira:** https://jira.splunk.com/browse/ADDON-37812

Changes:

- Kept only one-way routing to resolve multiple issues i.e. removed route updates from code

**Description:**
Because of how tabs are displayed (i.e. on tab visit we set CSS `display` property to show/hide them), it will fail to allow edit button click. This is caused when multiple tables tabs are used, both tables present in different tabs will revert URL query param and ultimately blocking the user from editing form. For reference: 

https://github.com/splunk/addonfactory-ucc-base-ui/blob/44576bcde18219085848f2852aa8c07c9fbdcfd1/src/main/webapp/components/table/CustomTable.jsx#L83-L87

We can overcome this by passing a prop that tells the table if it is active or not and only then update query params but that will make conditions more complex and prone to bugs.