### PR TITLE
Feature/addon 37808 enhance page errors' UX and UI

### DIFF
--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -47,8 +47,6 @@ class ErrorBoundary extends React.Component {
                         ) : null}
                         <details style={{ whiteSpace: 'pre-wrap' }}>
                             {this.state.error?.toString()}
-                            {/* <br />
-                            {this.state.errorInfo?.componentStack} */}
                         </details>
                     </Card.Body>
                     <Card.Footer showBorder={false}>

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import Heading from '@splunk/react-ui/Heading';
-import Message from '@splunk/react-ui/Message';
 import { _ } from '@splunk/ui-utils/i18n';
 import Card from '@splunk/react-ui/Card';
 import WarningIcon from '@splunk/react-icons/Warning'

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -43,7 +43,7 @@ class ErrorBoundary extends React.Component {
                     <Card.Body>
                         {this.state.errorCode ? (
                             <>
-                                {errorCodes[this.state.errorCode]}
+                                {_(errorCodes[this.state.errorCode])}
                                 <br/><br/>
                             </>
                         ) : null}

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -42,9 +42,10 @@ class ErrorBoundary extends React.Component {
                     </Card.Header>
                     <Card.Body>
                         {this.state.errorCode ? (
-                            <Message type="info">
+                            <>
                                 {errorCodes[this.state.errorCode]}
-                            </Message>
+                                <br/><br/>
+                            </>
                         ) : null}
                         <details style={{ whiteSpace: 'pre-wrap' }}>
                             {_(this.state.error?.toString())}

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -4,7 +4,9 @@ import PropTypes from 'prop-types';
 import Heading from '@splunk/react-ui/Heading';
 import Message from '@splunk/react-ui/Message';
 import { _ } from '@splunk/ui-utils/i18n';
-
+import Card from '@splunk/react-ui/Card';
+import Link from '@splunk/react-ui/Link';
+import WarningIcon from '@splunk/react-icons/Warning'
 import errorCodes from '../constants/errorCodes';
 
 class ErrorBoundary extends React.Component {
@@ -31,20 +33,29 @@ class ErrorBoundary extends React.Component {
         if (this.state.error) {
             // Error path
             return (
-                <>
-                    <Heading level={2}>
-                        {_('Something went wrong!')}
-                        {this.state.errorCode ? ` ERROR_CODE: ${this.state.errorCode}` : null}
-                    </Heading>
-                    {this.state.errorCode ? (
-                        <Message type="info">{errorCodes[this.state.errorCode]}</Message>
-                    ) : null}
-                    <details style={{ whiteSpace: 'pre-wrap' }}>
-                        {this.state.error?.toString()}
-                        <br />
-                        {this.state.errorInfo?.componentStack}
-                    </details>
-                </>
+                <div align="center" style={{ marginTop : "10%" }}>
+                <Card style={{ boxShadow : "10px 10px 5px #aaaaaa" }} >
+                    <Card.Header>
+                        <Heading style={{ textAlign:"center" }} level={2}>
+                            <WarningIcon style={{ fontSize: "120px", color: "#ff9900" }} /><br/><br/>
+                            {this.state.errorCode == 'ERR0001' ? 'Failed to load Inputs Page' : `${errorCodes[this.state.errorCode]}`}
+                        </Heading>
+                    </Card.Header>
+                    <Card.Body>
+                        {this.state.errorCode == 'ERR0001' ? (
+                            <Message type="info">This is normal on Splunk search heads as they do not require an Input page. Click <Link to="configuration" >here</Link> to return to the configuration page.</Message>
+                        ) : null}
+                        <details style={{ whiteSpace: 'pre-wrap' }}>
+                            {this.state.error?.toString()}
+                            {/* <br />
+                            {this.state.errorInfo?.componentStack} */}
+                        </details>
+                    </Card.Body>
+                    <Card.Footer showBorder={false}>
+                        {this.state.errorCode ? `${this.state.errorCode}` : null}
+                    </Card.Footer>
+                </Card>
+                </div>
             );
         }
         // Normally, just render children

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -5,7 +5,6 @@ import Heading from '@splunk/react-ui/Heading';
 import Message from '@splunk/react-ui/Message';
 import { _ } from '@splunk/ui-utils/i18n';
 import Card from '@splunk/react-ui/Card';
-import Link from '@splunk/react-ui/Link';
 import WarningIcon from '@splunk/react-icons/Warning'
 import errorCodes from '../constants/errorCodes';
 
@@ -38,12 +37,16 @@ class ErrorBoundary extends React.Component {
                     <Card.Header>
                         <Heading style={{ textAlign:"center" }} level={2}>
                             <WarningIcon style={{ fontSize: "120px", color: "#ff9900" }} /><br/><br/>
-                            {this.state.errorCode == 'ERR0001' ? 'Failed to load Inputs Page' : `${errorCodes[this.state.errorCode]}`}
+                            {this.state.errorCode === 'ERR0001' ? 'Failed to load Inputs Page' : 'Something went wrong!'}
                         </Heading>
                     </Card.Header>
                     <Card.Body>
-                        {this.state.errorCode == 'ERR0001' ? (
-                            <Message type="info">This is normal on Splunk search heads as they do not require an Input page. Click <Link to="configuration" >here</Link> to return to the configuration page.</Message>
+                        {this.state.errorCode ? (
+                            <>
+                            <Message type="info">
+                                {errorCodes[this.state.errorCode]}
+                            </Message>
+                            </>
                         ) : null}
                         <details style={{ whiteSpace: 'pre-wrap' }}>
                             {this.state.error?.toString()}

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -36,7 +36,7 @@ class ErrorBoundary extends React.Component {
                     <Card.Header>
                         <Heading style={{ textAlign:"center" }} level={2}>
                             <WarningIcon style={{ fontSize: "120px", color: "#ff9900" }} /><br/><br/>
-                            {this.state.errorCode === _('ERR0001') ? _('Failed to load Inputs Page') : _('Something went wrong!')}
+                            {this.state.errorCode === 'ERR0001' ? _('Failed to load Inputs Page') : _('Something went wrong!')}
                         </Heading>
                     </Card.Header>
                     <Card.Body>
@@ -47,7 +47,7 @@ class ErrorBoundary extends React.Component {
                             </>
                         ) : null}
                         <details style={{ whiteSpace: 'pre-wrap' }}>
-                            {_(this.state.error?.toString())}
+                            {this.state.error?.toString()}
                         </details>
                     </Card.Body>
                     <Card.Footer showBorder={false}>

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -37,23 +37,21 @@ class ErrorBoundary extends React.Component {
                     <Card.Header>
                         <Heading style={{ textAlign:"center" }} level={2}>
                             <WarningIcon style={{ fontSize: "120px", color: "#ff9900" }} /><br/><br/>
-                            {this.state.errorCode === 'ERR0001' ? 'Failed to load Inputs Page' : 'Something went wrong!'}
+                            {this.state.errorCode === _('ERR0001') ? _('Failed to load Inputs Page') : _('Something went wrong!')}
                         </Heading>
                     </Card.Header>
                     <Card.Body>
                         {this.state.errorCode ? (
-                            <>
                             <Message type="info">
                                 {errorCodes[this.state.errorCode]}
                             </Message>
-                            </>
                         ) : null}
                         <details style={{ whiteSpace: 'pre-wrap' }}>
-                            {this.state.error?.toString()}
+                            {_(this.state.error?.toString())}
                         </details>
                     </Card.Body>
                     <Card.Footer showBorder={false}>
-                        {this.state.errorCode ? `${this.state.errorCode}` : null}
+                        {this.state.errorCode ? this.state.errorCode : null}
                     </Card.Footer>
                 </Card>
                 </div>

--- a/src/main/webapp/constants/errorCodes.js
+++ b/src/main/webapp/constants/errorCodes.js
@@ -1,9 +1,0 @@
-export default {
-    ERR0001:
-        'Inputs page failed to load, the server reported internal errors which may indicate you do not have access to this page. This is normal on Splunk Search Heads.',
-    ERR0002:
-        'Configuration page failed to load, the server reported internal errors which may indicate you do not have access to this page.',
-    ERR0003: 'Failed to load content due to no response from server!',
-    ERR0004: 'Failed to load content due to failed request processing!',
-    ERR0005: 'Failed to load current state for selected entity in form!',
-};

--- a/src/main/webapp/constants/errorCodes.jsx
+++ b/src/main/webapp/constants/errorCodes.jsx
@@ -4,7 +4,7 @@ import Link from '@splunk/react-ui/Link';
 export default {
     ERR0001: (
         <>
-            This is normal on Splunk search heads as they do not require an Input page. Click <Link to="configuration">here</Link> to return to the configuration page.
+            This is normal on Splunk search heads as they do not require an Input page. Check your installation or return to the <Link to="configuration">configuration page</Link>.
         </>
     ),
     ERR0002: 'Configuration page failed to load, the server reported internal errors which may indicate you do not have access to this page.',

--- a/src/main/webapp/constants/errorCodes.jsx
+++ b/src/main/webapp/constants/errorCodes.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Link from '@splunk/react-ui/Link';
+
+export default {
+    ERR0001: (
+        <>
+            This is normal on Splunk search heads as they do not require an Input page. Click <Link to="configuration">here</Link> to return to the configuration page.
+        </>
+    ),
+    ERR0002: 'Configuration page failed to load, the server reported internal errors which may indicate you do not have access to this page.',
+    ERR0003: 'Failed to load content due to no response from server!',
+    ERR0004: 'Failed to load content due to failed request processing!',
+    ERR0005: 'Failed to load current state for selected entity in form!',
+};


### PR DESCRIPTION
Jira Link : https://jira.splunk.com/browse/ADDON-37808
- Used a card component in the middle of the page for errors.
- Showed Error Code in footer as that information is not as important to the user as it is to the developer.
- Added a info message in case the Inputs page does not load - that the splunk search heads do not need inputs page.
- Added a redirect to the configuration page os as not to leave the user stranded on the error page.

SS of the page : 


![image](https://user-images.githubusercontent.com/69460835/121295257-594de600-c90c-11eb-9e27-19ac832e0a59.png)

