### PR TITLE
fix: pass empty string to i18n if the field is optional

### DIFF
--- a/src/main/webapp/pages/Configuration/ConfigurationPage.jsx
+++ b/src/main/webapp/pages/Configuration/ConfigurationPage.jsx
@@ -65,7 +65,7 @@ function ConfigurationPage() {
                 <Row>
                     <ColumnLayout.Column span={9}>
                         <TitleComponent>{_(title)}</TitleComponent>
-                        <SubTitleComponent>{_(description)}</SubTitleComponent>
+                        <SubTitleComponent>{_(description || '')}</SubTitleComponent>
                     </ColumnLayout.Column>
                 </Row>
             </ColumnLayout>

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -192,7 +192,7 @@ function InputPage() {
                         <Row>
                             <ColumnLayout.Column span={9}>
                                 <TitleComponent>{_(title)}</TitleComponent>
-                                <SubTitleComponent>{_(description)}</SubTitleComponent>
+                                <SubTitleComponent>{_(description || '')}</SubTitleComponent>
                             </ColumnLayout.Column>
                             {services && services.length > 1 && !customMenuField?.src && (
                                 <ColumnLayout.Column className="dropdown" span={3}>


### PR DESCRIPTION
Jira: https://jira.splunk.com/browse/ADDON-37999

Description: When a TA does not include the `description` property in the `globalConfig.json` for configuration or inputs page. The schema validation passes because the field is optional but i18n will fail with error because of undefined value and it expects a string literal.

Changes:

- I checked all the occurrences of `_()` of i18n in the codebase and added an optional empty string in case the field is optional in `globalConfig.json` or can be undefined.