### PR TITLE
feat: apiVersion is not required anymore

### DIFF
--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -895,7 +895,7 @@
           "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
         }
       },
-      "required": ["displayName", "name", "restRoot", "apiVersion", "version"],
+      "required": ["displayName", "name", "restRoot", "version"],
       "additionalProperties": false
     },
     "NumberValidator": {

--- a/src/main/webapp/schema/schemaGenerator.py
+++ b/src/main/webapp/schema/schemaGenerator.py
@@ -59,12 +59,12 @@ class ValidatorBase(DocumentWithoutAddProp):
     errorMsg = StringField(max_length=400)
 
 
-# MetaData component for detailing brief imformation of document/component
+# MetaData component for detailing brief information of document/component
 class Meta(DocumentWithoutAddProp):
     displayName = StringField(required=True, max_length=200)
     name = StringField(required=True, pattern="^[^<>\:\"\/\\\|\?\*]+$")
     restRoot = StringField(required=True, pattern="^\w+$")
-    apiVersion = StringField(required=True, pattern="^(?:\d{1,3}\.){2}\d{1,3}$")
+    apiVersion = StringField(required=False, pattern="^(?:\d{1,3}\.){2}\d{1,3}$")
     version = StringField(required=True)
     schemaVersion = StringField( pattern="^(?:\d{1,3}\.){2}\d{1,3}$")
 
@@ -349,7 +349,7 @@ class Technology(DocumentWithoutAddProp):
 
 
 ##
-# Main Component holding the alert actions 
+# Main Component holding the alert actions
 ##
 class Alerts(DocumentWithoutAddProp):
     name = StringField(required=True, pattern="^[a-zA-Z0-9_]+$", max_length=100)


### PR DESCRIPTION
This PR marks `apiVersion` as not required in `meta` configuration of globalConfig.json.

This should not break anything in the existing add-ons and `ucc-gen` should work fine with this change.

It will be removed in couple of next releases.