### PR TITLE
fix: skip `null` value fields from displaying in table expansion row

### DIFF
--- a/src/main/webapp/components/table/TableExpansionRow.jsx
+++ b/src/main/webapp/components/table/TableExpansionRow.jsx
@@ -18,7 +18,7 @@ function getExpansionRowData(row, moreInfo) {
         moreInfo.forEach((val) => {
             const label = _(val.label);
             // remove extra rows which are empty in moreInfo
-            if (val.field in row && row[val.field] !== '') {
+            if (val.field in row && row[val.field] !== null && row[val.field] !== '') {
                 DefinitionLists.push(<DL.Term key={val.field}>{label}</DL.Term>);
                 DefinitionLists.push(
                     <DL.Description key={`${val.field}_decr`}>


### PR DESCRIPTION
Jira: https://jira.splunk.com/browse/ADDON-39037