### PR TITLE
feat: support custom REST handlers

### DIFF
--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -844,6 +844,14 @@
               "restHandlerName": {
                 "type": "string",
                 "maxLength": 100
+              },
+              "restHandlerModule": {
+                "type": "string",
+                "maxLength": 100
+              },
+              "restHandlerClass": {
+                "type": "string",
+                "maxLength": 100
               }
             },
             "required": [
@@ -1149,6 +1157,14 @@
           "maxLength": 100
         },
         "restHandlerName": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "restHandlerModule": {
+          "type": "string",
+          "maxLength": 100
+        },
+        "restHandlerClass": {
           "type": "string",
           "maxLength": 100
         },


### PR DESCRIPTION
This PR adds a support for custom REST handler module and custom REST handler class. It keeps `restHandlerName` in place to be compatible with the add-ons which are using it.

The idea of the `restHandlerName` is not to generate the REST handler and directly use the one which is provided. For example, check https://github.com/splunk/splunk-add-on-for-crowdstrike-fdr/blob/139048ac9f44ea47e7e3d12531bb7a38eee5cfd2/globalConfig.json#L8. There are only couple of add-ons using this field, so we can potentially migrate them to use `restHandlerModule` and `restHandlerClass` in the future.

The idea of the `restHandlerModule` and `restHandlerClass` is to generate a default REST handler which uses `restHandlerClass` from `restHandlerModule` module instead of the default option (`from splunktaucclib.rest_handler.admin_external import AdminExternalHandler`).

Towards https://github.com/splunk/addonfactory-ucc-generator/issues/520