### PR TITLE
fix(CODE): ADDON-57152 Fixed tabs clicking issue when style is set to page

### DIFF
--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -43,7 +43,7 @@ function InputPage() {
 
     // Used for outer table is present or not
     const table = unifiedConfigs.pages.inputs?.table;
-    const isOuterTable = table ? true : false;
+    const isOuterTable = !!table;
 
     const [activeTabId, setActiveTabId] = useState(services[0].name);
     const [selectedTabDescription, setSelectedTabDescription] = useState(services[0]?.description || "");
@@ -173,7 +173,6 @@ function InputPage() {
     // handle close request for page style dialog
     const handlePageDialogClose = () => {
         setEntity({ ...entity, open: false });
-        query.delete('service');
         query.delete('action');
         history.push({ search: query.toString() });
     };
@@ -207,8 +206,10 @@ function InputPage() {
         }
 
         query.set('service', selectedTabId);
+        query.delete('action');
         history.push({ search: query.toString() });
 
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [activeTabId]);
 
     // Making a dropdown if we have more than one service


### PR DESCRIPTION
**Steps to reproduce:**

- In the Inputs tab, set `style: page` in the globalConfig file
- Click on the tab
- Click on Add, Edit, or Clone button
- It will open a form on the new page
- Click on the Cancel button
- Now change the tab
- It's opening a new page instead of opening a tabs content (Table view)
