### PR TITLE
feat(CODE): ADDON-57044 Added new support for Textarea field

### DIFF
--- a/src/main/webapp/components/TextAreaComponent.jsx
+++ b/src/main/webapp/components/TextAreaComponent.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import TextArea from '@splunk/react-ui/TextArea';
+import styled from 'styled-components';
+
+const TextWrapper = styled(TextArea)`
+    width: 320px !important;
+`;
+
+function TextAreaComponent(props) {
+
+    const handleChange = (e, { value }) => {
+        props.handleChange(props.field, value);
+    };
+
+    return (
+        <TextWrapper
+            inline
+            canClear
+            error={props.error}
+            placeholder={props?.controlOptions?.placeholder}
+            className={props.field}
+            disabled={props.disabled}
+            value={props.value?.toString() || ''}
+            onChange={handleChange}
+            rowsMax={props?.controlOptions?.rowsMax ? props?.controlOptions?.rowsMax : 12}
+            rowsMin={props?.controlOptions?.rowsMin ? props?.controlOptions?.rowsMin : 8}
+        />
+    );
+
+}
+
+TextAreaComponent.propTypes = {
+    value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    handleChange: PropTypes.func.isRequired,
+    field: PropTypes.string,
+    error: PropTypes.bool,
+    controlOptions: PropTypes.object,
+    disabled: PropTypes.bool,
+};
+
+export default TextAreaComponent;

--- a/src/main/webapp/constants/ControlTypeMap.js
+++ b/src/main/webapp/constants/ControlTypeMap.js
@@ -1,5 +1,6 @@
 import HelpLinkComponent from '../components/HelpLinkComponent';
 import TextComponent from '../components/TextComponent';
+import TextAreaComponent from '../components/TextAreaComponent';
 import SingleInputComponent from '../components/SingleInputComponent';
 import MultiInputComponent from '../components/MultiInputComponent';
 import CheckBoxComponent from '../components/CheckBoxComponent';
@@ -9,6 +10,7 @@ import CustomControl from '../components/CustomControl';
 
 export default {
     text: TextComponent,
+    textarea: TextAreaComponent,
     singleSelect: SingleInputComponent,
     helpLink: HelpLinkComponent,
     multipleSelect: MultiInputComponent,

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -170,6 +170,7 @@
           "enum": [
             "custom",
             "text",
+            "textarea",
             "singleSelect",
             "checkbox",
             "multipleSelect",
@@ -339,6 +340,12 @@
             },
             "link": {
               "type": "string"
+            },
+            "rowsMin": {
+              "type": "number"
+            },
+            "rowsMax": {
+              "type": "number"
             }
           }
         },
@@ -546,6 +553,7 @@
           "enum": [
             "custom",
             "text",
+            "textarea",
             "singleSelect",
             "checkbox",
             "multipleSelect",
@@ -712,6 +720,12 @@
             },
             "link": {
               "type": "string"
+            },
+            "rowsMin": {
+              "type": "number"
+            },
+            "rowsMax": {
+              "type": "number"
             }
           }
         },


### PR DESCRIPTION
Added support for Textarea filed. 

Validators, options, help, defaultValue, etc. fields are supported to use textarea component/filed.

GlobalConfig json file looks like this:

```
{
    "type": "textarea",
    "label": "Textarea Field",
    "field": "textarea_field",
    "help": "Help message",
    "options": {
        "rowsMin": 3,
        "rowsMax": 15
    },
    "required": true
}
```