### PR TITLE
feat: ADDON-57046: Added file input component

### DIFF
--- a/src/main/webapp/components/FileInputComponent.jsx
+++ b/src/main/webapp/components/FileInputComponent.jsx
@@ -31,8 +31,13 @@ function FileInputComponent(props) {
       fileReader.readAsBinaryString(file);
 
       fileReader.onload = () => {
+        const value = {
+            fileName: file.name,
+            fileSize: file.size,
+            fileContent: fileReader.result
+        };
         setFileName(file.name);
-        handleChange(field, fileReader.result);
+        handleChange(field, value);
       };
     };
   };
@@ -51,9 +56,10 @@ function FileInputComponent(props) {
       onRequestAdd={handleAddFiles}
       onRequestRemove={handleRemoveFile}
       supportsMessage={
-        <> {controlOptions?.supportsMessage} </>
+        <> {controlOptions?.fileSupportMessage} </>
       }
       disabled={disabled}
+      accept=".json"
     >
       {fileName && <File.Item error={error}  name={fileName} />}
     </FileWrapper>

--- a/src/main/webapp/components/FileInputComponent.jsx
+++ b/src/main/webapp/components/FileInputComponent.jsx
@@ -7,6 +7,8 @@ const FileWrapper = styled(File)`
     width: 320px !important;
 `;
 
+const supportedFileTypes = ".json";
+
 function FileInputComponent(props) {
   const {
     field,
@@ -59,7 +61,7 @@ function FileInputComponent(props) {
         <> {controlOptions?.fileSupportMessage} </>
       }
       disabled={disabled}
-      accept=".json"
+      accept={supportedFileTypes}
     >
       {fileName && <File.Item error={error}  name={fileName} />}
     </FileWrapper>

--- a/src/main/webapp/components/FileInputComponent.jsx
+++ b/src/main/webapp/components/FileInputComponent.jsx
@@ -1,0 +1,70 @@
+import React, { Component, useState } from 'react';
+import File from "@splunk/react-ui/File";
+import styled from 'styled-components';
+import PropTypes from 'prop-types';
+
+const FileWrapper = styled(File)`
+    width: 320px !important;
+`;
+
+function FileInputComponent(props) {
+  const {
+    field,
+    disabled,
+    error,
+    controlOptions,
+    handleChange
+} = props;
+
+  const fileReader = new FileReader();
+
+  const [fileName, setFileName] = useState("");
+
+  const handleAddFiles = (files) => {
+    if (files.length) {
+      const file = files[0];
+
+      if (fileReader.readyState === 1) {
+        fileReader.abort();
+      };
+
+      fileReader.readAsBinaryString(file);
+
+      fileReader.onload = () => {
+        setFileName(file.name);
+        handleChange(field, fileReader.result);
+      };
+    };
+  };
+
+  const handleRemoveFile = () => {
+      if (fileReader.readyState === 1) {
+        fileReader.abort();
+      };
+      setFileName(null);
+      handleChange(field, null);
+  };
+
+  return(
+    <FileWrapper
+      key={field}
+      onRequestAdd={handleAddFiles}
+      onRequestRemove={handleRemoveFile}
+      supportsMessage={
+        <> {controlOptions?.supportsMessage} </>
+      }
+      disabled={disabled}
+    >
+      {fileName && <File.Item error={error}  name={fileName} />}
+    </FileWrapper>
+  );
+}
+
+FileInputComponent.propTypes = {
+    field: PropTypes.string,
+    error: PropTypes.bool,
+    controlOptions: PropTypes.object,
+    disabled: PropTypes.bool,
+};
+
+export default FileInputComponent;

--- a/src/main/webapp/constants/ControlTypeMap.js
+++ b/src/main/webapp/constants/ControlTypeMap.js
@@ -7,6 +7,7 @@ import CheckBoxComponent from '../components/CheckBoxComponent';
 import RadioComponent from '../components/RadioComponent';
 import PlaceholderComponent from '../components/PlaceholderComponent';
 import CustomControl from '../components/CustomControl';
+import FileInputComponent from '../components/FileInputComponent';
 
 export default {
     text: TextComponent,
@@ -16,6 +17,7 @@ export default {
     multipleSelect: MultiInputComponent,
     checkbox: CheckBoxComponent,
     radio: RadioComponent,
+    file: FileInputComponent,
     placeholder: PlaceholderComponent,
     custom: CustomControl,
 };

--- a/src/main/webapp/constants/constant.js
+++ b/src/main/webapp/constants/constant.js
@@ -1,0 +1,3 @@
+export default {
+    MAX_SIZE: '512000'
+};

--- a/src/main/webapp/constants/constant.js
+++ b/src/main/webapp/constants/constant.js
@@ -1,3 +1,3 @@
 export default {
-    MAX_SIZE: '512000'
+    FILE_MAX_SIZE: '512000'
 };

--- a/src/main/webapp/constants/messageDict.js
+++ b/src/main/webapp/constants/messageDict.js
@@ -24,7 +24,8 @@ export default {
     22: 'Field {{args[0]}} must be less than 1024 characters',
     23: '"name" feild must be provided for {{args[0]}} \'s entity in configuration file',
     24: 'The file must be in {{args[0]}} format',
-    25: 'The file size should not exceed 2MB',
+    25: 'The file size should not exceed {{args[0]}}',
+    26: 'Invalid JSON file',
 
     // general messages, range [100, 499]
     100: 'Create New Input',

--- a/src/main/webapp/constants/messageDict.js
+++ b/src/main/webapp/constants/messageDict.js
@@ -23,6 +23,8 @@ export default {
     21: 'duplicate {{args[0]}} keys is not allowed',
     22: 'Field {{args[0]}} must be less than 1024 characters',
     23: '"name" feild must be provided for {{args[0]}} \'s entity in configuration file',
+    24: 'The file must be in {{args[0]}} format',
+    25: 'The file size should not exceed 2MB',
 
     // general messages, range [100, 499]
     100: 'Create New Input',

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -177,7 +177,8 @@
             "radio",
             "placeholder",
             "oauth",
-            "helpLink"
+            "helpLink",
+            "file"
           ]
         },
         "help": {
@@ -241,6 +242,10 @@
               ]
             },
             "endpointUrl": {
+              "type": "string",
+              "maxLength": 350
+            },
+            "supportsMessage": {
               "type": "string",
               "maxLength": 350
             },
@@ -379,6 +384,9 @@
               },
               {
                 "$ref": "#/definitions/DateValidator"
+              },
+              {
+                "$ref": "#/definitions/FileValidator"
               }
             ]
           }
@@ -497,10 +505,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "date"
-          ]
+          "const": "date"
         }
       },
       "required": [
@@ -516,10 +521,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "email"
-          ]
+          "const": "email"
         }
       },
       "required": [
@@ -560,7 +562,8 @@
             "radio",
             "placeholder",
             "oauth",
-            "helpLink"
+            "helpLink",
+            "file"
           ]
         },
         "help": {
@@ -759,6 +762,9 @@
               },
               {
                 "$ref": "#/definitions/DateValidator"
+              },
+              {
+                "$ref": "#/definitions/FileValidator"
               }
             ]
           }
@@ -1089,10 +1095,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "ipv4"
-          ]
+          "const": "ipv4"
         }
       },
       "required": [
@@ -1143,10 +1146,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "number"
-          ]
+          "const": "number"
         },
         "range": {
           "type": "array",
@@ -1159,6 +1159,25 @@
         "type",
         "range"
       ],
+      "additionalProperties": false
+    },
+    "FileValidator": {
+      "type": "object",
+      "properties": {
+        "errorMsg": {
+          "type": "string",
+          "maxLength": 400
+        },
+        "type": {
+          "const": "file"
+        },
+        "supportedFileTypes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
       "additionalProperties": false
     },
     "OAuthFields": {
@@ -1219,10 +1238,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "regex"
-          ]
+          "const": "regex"
         },
         "pattern": {
           "type": "string"
@@ -1242,10 +1258,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "string"
-          ]
+          "const": "string"
         },
         "minLength": {
           "type": "number",
@@ -1349,10 +1362,7 @@
           "maxLength": 400
         },
         "type": {
-          "type": "string",
-          "enum": [
-            "url"
-          ]
+          "const": "url"
         }
       },
       "required": [

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -245,7 +245,7 @@
               "type": "string",
               "maxLength": 350
             },
-            "supportsMessage": {
+            "fileSupportMessage": {
               "type": "string",
               "maxLength": 350
             },

--- a/src/main/webapp/util/Validator.js
+++ b/src/main/webapp/util/Validator.js
@@ -146,8 +146,8 @@ class Validator {
                     errorMsg: validator.errorMsg || getFormattedMessage(24, [validator.supportedFileTypes])
                 };
             }
-            if(fileSize > FILE.MAX_SIZE) {
-                const file_size = FILE.MAX_SIZE/1024 + "KB";
+            if(fileSize > FILE.FILE_MAX_SIZE) {
+                const file_size = FILE.FILE_MAX_SIZE/1024 + "KB";
                 return {
                     errorField: field,
                     errorMsg: getFormattedMessage(25, [file_size])

--- a/src/main/webapp/util/Validator.js
+++ b/src/main/webapp/util/Validator.js
@@ -7,6 +7,7 @@ import {
     parseFunctionRawStr,
     parseFileValidator
 } from './uccConfigurationValidators';
+import FILE from "../constants/constant";
 
 // Validate provided saveValidator function
 export function SaveValidator(validatorFunc, formData) {
@@ -138,17 +139,24 @@ class Validator {
 
     FileValidator(field, validator, data) {
         if(data) {
-            const { isValidExtention, getFileSize } = parseFileValidator(data, validator.supportedFileTypes);
-            if(!isValidExtention) {
+            const { isValidExtension, fileSize, isValidContent } = parseFileValidator(data, validator.supportedFileTypes);
+            if(!isValidExtension) {
                 return {
                     errorField: field,
                     errorMsg: validator.errorMsg || getFormattedMessage(24, [validator.supportedFileTypes])
                 };
             }
-            if(getFileSize > 2000000) {
+            if(fileSize > FILE.MAX_SIZE) {
+                const file_size = FILE.MAX_SIZE/1024 + "KB";
                 return {
                     errorField: field,
-                    errorMsg: getFormattedMessage(25)
+                    errorMsg: getFormattedMessage(25, [file_size])
+                };
+            }
+            if (!isValidContent) {
+                return {
+                    errorField: field,
+                    errorMsg: getFormattedMessage(26)
                 };
             }
         }

--- a/src/main/webapp/util/Validator.js
+++ b/src/main/webapp/util/Validator.js
@@ -5,6 +5,7 @@ import {
     parseRegexRawStr,
     parseStringValidator,
     parseFunctionRawStr,
+    parseFileValidator
 } from './uccConfigurationValidators';
 
 // Validate provided saveValidator function
@@ -131,6 +132,25 @@ class Validator {
                     ? validator.errorMsg
                     : getFormattedMessage(8, [label, validator.range[0], validator.range[1]]),
             };
+        }
+        return false;
+    }
+
+    FileValidator(field, validator, data) {
+        if(data) {
+            const { isValidExtention, getFileSize } = parseFileValidator(data, validator.supportedFileTypes);
+            if(!isValidExtention) {
+                return {
+                    errorField: field,
+                    errorMsg: validator.errorMsg || getFormattedMessage(24, [validator.supportedFileTypes])
+                };
+            }
+            if(getFileSize > 2000000) {
+                return {
+                    errorField: field,
+                    errorMsg: getFormattedMessage(25)
+                };
+            }
         }
         return false;
     }
@@ -266,6 +286,16 @@ class Validator {
                                 data[this.entities[i].field],
                                 PREDEFINED_VALIDATORS_DICT.ipv4.regex,
                                 PREDEFINED_VALIDATORS_DICT.ipv4.inputValueType
+                            );
+                            if (ret) {
+                                return ret;
+                            }
+                            break;
+                        case 'file':
+                            ret = this.FileValidator(
+                                this.entities[i].field,
+                                this.entities[i].validators[j],
+                                data[this.entities[i].field]
                             );
                             if (ret) {
                                 return ret;

--- a/src/main/webapp/util/uccConfigurationValidators.js
+++ b/src/main/webapp/util/uccConfigurationValidators.js
@@ -67,9 +67,8 @@ export const parseFunctionRawStr = (rawStr) => {
 export const parseFileValidator = (data, validFileTypes) => {
     
     const { fileName, fileSize, fileContent } = data;
-    const file_name = fileName.split(".");
-    const extension = "." + file_name[file_name.length - 1];
-    const isValidExtension = validFileTypes.findIndex((fileExtension) => fileExtension === extension) !== -1;
+    const givenFileExtension = fileName.split(".").pop();
+    const isValidExtension = validFileTypes.findIndex((fileExtension) => fileExtension === givenFileExtension) !== -1;
 
     let isValidContent = true;
 

--- a/src/main/webapp/util/uccConfigurationValidators.js
+++ b/src/main/webapp/util/uccConfigurationValidators.js
@@ -65,15 +65,22 @@ export const parseFunctionRawStr = (rawStr) => {
 };
 
 export const parseFileValidator = (data, validFileTypes) => {
+    
+    const { fileName, fileSize, fileContent } = data;
+    const file_name = fileName.split(".");
+    const extension = "." + file_name[file_name.length - 1];
+    const isValidExtension = validFileTypes.findIndex((fileExtension) => fileExtension === extension) !== -1;
 
-    const fileName = data.split(",")[0].split(".");
-    const extention = fileName[fileName.length - 1];
-    const isValidExtention = validFileTypes.map((file) => (file.replace(/\./g, ''))).includes(extention);
+    let isValidContent = true;
 
-    const getFileSize = data?.split(",")[1];    
+    try {
+        JSON.parse(fileContent);
+    } catch (err) {
+        isValidContent = false;
+    }
 
-    return { isValidExtention, getFileSize };
-}
+    return { isValidExtension, fileSize, isValidContent };
+};
 
 export const checkDupKeyValues = (config, isInput, location) => {
     // Forbid dup name/title in services and tabs

--- a/src/main/webapp/util/uccConfigurationValidators.js
+++ b/src/main/webapp/util/uccConfigurationValidators.js
@@ -64,6 +64,17 @@ export const parseFunctionRawStr = (rawStr) => {
     return { error, result };
 };
 
+export const parseFileValidator = (data, validFileTypes) => {
+
+    const fileName = data.split(",")[0].split(".");
+    const extention = fileName[fileName.length - 1];
+    const isValidExtention = validFileTypes.map((file) => (file.replace(/\./g, ''))).includes(extention);
+
+    const getFileSize = data?.split(",")[1];    
+
+    return { isValidExtention, getFileSize };
+}
+
 export const checkDupKeyValues = (config, isInput, location) => {
     // Forbid dup name/title in services and tabs
     const servicesLikeArr = _.get(config, isInput ? 'services' : 'tabs');


### PR DESCRIPTION
This is how we can use file input in the global config file -
```

{
    "type": "file",
    "label": "Service Account's certificate",
    "help": "Content of the service account's downloaded JSON key.",
    "field": "certificate",
    "options": {
        "fileSupportMessage": "We only support json file"
    },
    "validators": [
        {
            "type": "file",
            "supportedFileTypes": ["json"]
        }
    ],
    "required": true,
    "encrypted": true
}

```

**Notes:**

- We only support JSON file
- Maximum file size is 500KB

**Output:**

<img width="828" alt="Screenshot 2022-12-08 at 11 26 56 AM" src="https://user-images.githubusercontent.com/62089106/206368907-57f7c88e-6035-4b5d-9efb-7de96c111a99.png">


