### PR TITLE
ADDON-57046: Sending file content as a string in the payload

### DIFF
--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -591,7 +591,11 @@ class BaseFormView extends PureComponent {
         const body = new URLSearchParams();
         Object.keys(this.datadict).forEach((key) => {
             if (this.datadict[key] != null) {
-                body.append(key, this.datadict[key]);
+                if (typeof (this.datadict[key]) === 'object') {
+                    body.append(key, JSON.stringify(this.datadict[key]));
+                } else {
+                    body.append(key, this.datadict[key]);
+                }
             }
         });
 

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -591,8 +591,8 @@ class BaseFormView extends PureComponent {
         const body = new URLSearchParams();
         Object.keys(this.datadict).forEach((key) => {
             if (this.datadict[key] != null) {
-                if (typeof (this.datadict[key]) === 'object') {
-                    body.append(key, JSON.stringify(this.datadict[key]));
+                if (typeof (this.datadict[key]) === 'object' && this.entities.find((x) => x.field === key).type === 'file') {
+                    body.append(key, this.datadict[key].fileContent);
                 } else {
                     body.append(key, this.datadict[key]);
                 }

--- a/src/main/webapp/components/FileInputComponent.jsx
+++ b/src/main/webapp/components/FileInputComponent.jsx
@@ -49,7 +49,7 @@ function FileInputComponent(props) {
         fileReader.abort();
       };
       setFileName(null);
-      handleChange(field, null);
+      handleChange(field, '');
   };
 
   return(


### PR DESCRIPTION
File input is only sending the fileContent now, instead of sending the object which is incorrectly stored in the backend (like, `[object Object]`).