### PR TITLE
fix: ADDON-58705 Table action buttons are dynamic from the global config file

### DIFF
--- a/src/main/webapp/components/table/CustomTable.jsx
+++ b/src/main/webapp/components/table/CustomTable.jsx
@@ -33,11 +33,11 @@ function CustomTable({
 
     const { rowData } = useContext(TableContext);
 
-    const { moreInfo, header } = tableConfig;
-    const headers = tableConfig.header;
+    const { moreInfo, header: headers, actions } = tableConfig;
+    // const headers = tableConfig.header;
 
     const headerMapping = {};
-    header.forEach((x) => {
+    headers.forEach((x) => {
         headerMapping[x.field] = x.mapping;
     });
 
@@ -188,7 +188,11 @@ function CustomTable({
                 });
             });
         }
-        column.push({ label: 'Actions', field: 'actions', sortKey: '' });
+
+        if (actions && actions.length) {
+            column.push({ label: 'Actions', field: 'actions', sortKey: '' });
+        }
+
         return column;
     };
 
@@ -225,6 +229,7 @@ function CustomTable({
                         key={row.id}
                         row={row}
                         columns={columns}
+                        rowActions={actions}
                         headerMapping={headerMapping}
                         {...{
                             handleEditActionClick,

--- a/src/main/webapp/components/table/CustomTable.jsx
+++ b/src/main/webapp/components/table/CustomTable.jsx
@@ -34,7 +34,6 @@ function CustomTable({
     const { rowData } = useContext(TableContext);
 
     const { moreInfo, header: headers, actions } = tableConfig;
-    // const headers = tableConfig.header;
 
     const headerMapping = {};
     headers.forEach((x) => {

--- a/src/main/webapp/components/table/CustomTableRow.jsx
+++ b/src/main/webapp/components/table/CustomTableRow.jsx
@@ -32,6 +32,7 @@ function CustomTableRow(props) {
     const {
         row,
         columns,
+        rowActions,
         headerMapping,
         handleToggleActionClick,
         handleEditActionClick,
@@ -52,33 +53,40 @@ function CustomTableRow(props) {
         (selectedRow) => (
             <TableCellWrapper data-column="actions" key={selectedRow.id}>
                 <ButtonGroup>
-                    <Tooltip content={_('Edit')}>
-                        <ActionButtonComponent
-                            appearance="flat"
-                            icon={<Pencil screenReaderText={null} size={1} />}
-                            onClick={() => handleEditActionClick(selectedRow)}
-                            className="editBtn"
-                        />
-                    </Tooltip>
-                    <Tooltip content={_('Clone')}>
-                        <ActionButtonComponent
-                            appearance="flat"
-                            icon={<Clone screenReaderText={null} size={1} />}
-                            onClick={() => handleCloneActionClick(selectedRow)}
-                            className="cloneBtn"
-                        />
-                    </Tooltip>
-                    <Tooltip content={_('Delete')}>
-                        <ActionButtonComponent
-                            appearance="destructive"
-                            icon={<Trash screenReaderText={null} size={1} />}
-                            onClick={() => handleDeleteActionClick(selectedRow)}
-                            className="deleteBtn"
-                        />
-                    </Tooltip>
+                    {rowActions.includes('edit') && (
+                        <Tooltip content={_('Edit')}>
+                            <ActionButtonComponent
+                                appearance="flat"
+                                icon={<Pencil screenReaderText={null} size={1} />}
+                                onClick={() => handleEditActionClick(selectedRow)}
+                                className="editBtn"
+                            />
+                        </Tooltip>
+                    )}
+                    {rowActions.includes('clone') && (
+                        <Tooltip content={_('Clone')}>
+                            <ActionButtonComponent
+                                appearance="flat"
+                                icon={<Clone screenReaderText={null} size={1} />}
+                                onClick={() => handleCloneActionClick(selectedRow)}
+                                className="cloneBtn"
+                            />
+                        </Tooltip>
+                    )}
+                    {rowActions.includes('delete') && (
+                        <Tooltip content={_('Delete')}>
+                            <ActionButtonComponent
+                                appearance="destructive"
+                                icon={<Trash screenReaderText={null} size={1} />}
+                                onClick={() => handleDeleteActionClick(selectedRow)}
+                                className="deleteBtn"
+                            />
+                        </Tooltip>
+                    )}
                 </ButtonGroup>
             </TableCellWrapper>
         ),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
         [handleEditActionClick, handleCloneActionClick, handleDeleteActionClick]
     );
 
@@ -166,6 +174,7 @@ function CustomTableRow(props) {
 CustomTableRow.propTypes = {
     row: PropTypes.any,
     columns: PropTypes.array,
+    rowActions: PropTypes.array,
     headerMapping: PropTypes.object,
     handleToggleActionClick: PropTypes.func,
     handleEditActionClick: PropTypes.func,

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -1011,7 +1011,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["edit", "delete", "clone"]
+            "enum": ["edit", "delete", "clone", "enable"]
           }
         }
       },

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -1011,7 +1011,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["edit", "delete", "clone", "enable"]
+            "enum": ["edit", "delete", "clone"]
           }
         }
       },


### PR DESCRIPTION
**Jira Link** - https://splunk.atlassian.net/browse/ADDON-58705

Now the UCC should take care of the actions given in the global config file and accordingly it will render the **Actions button** in the table. For Example -

**Global config snippet:**
```

"inputs": {
            "table": {
                "actions": [
                    "edit"
                ],
                "header": [
                    {
                        "label": "Name",
                        "field": "name"
                    },
                ......
                ......
                 ]
           }
}

```
**Output:**
<img width="1788" alt="Screenshot 2023-01-12 at 6 40 08 PM" src="https://user-images.githubusercontent.com/62089106/212074954-73a8f079-3eea-478d-b936-86d5c5565d9c.png">

> **Note:** Currently, the actions list supports "edit," "delete," "clone," and "enable," but **enable** is deprecated and will be removed in the upcoming release of the ucc-gen.