### PR TITLE
refactor: ADDON-59779 Refactored single input component

### DIFF
--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -700,8 +700,6 @@ class BaseFormView extends PureComponent {
                     if (required && !currentValue) {
                         load = false;
                         data[dependency] = null;
-                    } else if (currentValue === 'RESET_DROPDOWN_VALUE') {
-                        load = true;
                     } else {
                         data[dependency] = currentValue;
                     }
@@ -716,14 +714,7 @@ class BaseFormView extends PureComponent {
             });
         }
 
-        /*
-         * Custom logic to handle the dropdown's reset value by clicking "X" button.
-         * DO NOT CHANGE: value of targetValue to null or any other value. Keep it as blank string only.
-         * Reason: We are sending a blank string value in the API, and this validation is inside the saveData().
-         */
-
-        const updatedTargetValue = targetValue === 'RESET_DROPDOWN_VALUE' ? '' : targetValue;
-        changes[field] = { value: { $set: updatedTargetValue } };
+        changes[field] = { value: { $set: targetValue } };
 
         const newFields = update(this.state, { data: changes });
         const tempState = this.clearAllErrorMsg(newFields);
@@ -732,7 +723,7 @@ class BaseFormView extends PureComponent {
         if (this.hookDeferred) {
             this.hookDeferred.then(() => {
                 if (typeof this.hook.onChange === 'function') {
-                    this.hook.onChange(field, updatedTargetValue, tempState);
+                    this.hook.onChange(field, targetValue, tempState);
                 }
             });
         }

--- a/src/main/webapp/components/ControlWrapper.jsx
+++ b/src/main/webapp/components/ControlWrapper.jsx
@@ -38,7 +38,15 @@ class ControlWrapper extends React.PureComponent {
     }
 
     render() {
-        const { field, type, label, tooltip, help, encrypted = false } = this.props.entity;
+        const {
+            field,
+            type,
+            label,
+            tooltip,
+            help,
+            encrypted = false,
+            required,
+        } = this.props.entity;
         const { handleChange, addCustomValidator, utilCustomFunctions } = this.props.utilityFuncts;
         // We have to put empty object because markDownMessage prop can be undefined
         // because we are not explicitly setting it but expecting it from custom hooks only.
@@ -73,6 +81,7 @@ class ControlWrapper extends React.PureComponent {
                       disabled: this.props.disabled,
                       encrypted,
                       dependencyValues: this.props.dependencyValues,
+                      required,
                   })
                 : `No View Found for ${type} type`;
         }

--- a/src/main/webapp/components/SingleInputComponent.jsx
+++ b/src/main/webapp/components/SingleInputComponent.jsx
@@ -89,7 +89,7 @@ function SingleInputComponent(props) {
         if (dependencyValues) {
             options.params = { ...options.params, ...dependencyValues };
         }
-        if (!dependencies || (dependencyValues && Object.keys(dependencyValues).length)) {
+        if (!dependencies || dependencyValues) {
             setLoading(true);
             axiosCallWrapper(options)
                 .then((response) => {
@@ -106,6 +106,7 @@ function SingleInputComponent(props) {
                     if (current) {
                         setLoading(false);
                     }
+                    setOptions(null);
                 });
         } else {
             setOptions(null);
@@ -121,7 +122,8 @@ function SingleInputComponent(props) {
     const effectiveDisabled = loading ? true : disabled;
     const effectivePlaceholder = loading ? _('Loading') : placeholder;
     // hideClearBtn=true only passed for OAuth else its undefined
-    const effectiveIsClearable = effectiveDisabled ? false : !hideClearBtn;
+    // effectiveIsClearable button will be visible only for the required=false and createSearchChoice=false single-select fields.
+    const effectiveIsClearable = !(effectiveDisabled || restProps.required || hideClearBtn);
 
     return createSearchChoice ? (
         <StyledDiv className="dropdownBox">
@@ -158,7 +160,7 @@ function SingleInputComponent(props) {
                     data-test="clear"
                     appearance="secondary"
                     icon={<Clear />}
-                    onClick={() => restProps.handleChange(field, 'RESET_DROPDOWN_VALUE')}
+                    onClick={() => restProps.handleChange(field, '')}
                 />
             ) : null}
         </>
@@ -185,6 +187,7 @@ SingleInputComponent.propTypes = {
         labelField: PropTypes.string,
         hideClearBtn: PropTypes.bool,
     }),
+    required: PropTypes.bool,
 };
 
 export default SingleInputComponent;


### PR DESCRIPTION
**Jira Link** - https://splunk.atlassian.net/browse/ADDON-59779

We are modifying the code for the single input component. The changes are that if that field is marked as required, the option to clear the field value is no longer displayed. Otherwise, we'll have a clear button to remove the field value.
If a required field is not specified in the globalConfig file, we internally mark it as optional and display a clear button along with a select box.

Here is the output when we have required to false (or the complete required field is not present in the globalConfig file) -
<img width="631" alt="Screenshot 2023-02-13 at 5 55 51 PM" src="https://user-images.githubusercontent.com/62089106/218457183-a0c5fa41-8cf4-46c6-b3a5-d7f8ee171f29.png">

When required set to true-
<img width="609" alt="Screenshot 2023-02-13 at 6 04 45 PM" src="https://user-images.githubusercontent.com/62089106/218459237-ec826443-8c01-4a5e-89b4-97667db0e653.png">
