### PR TITLE
fix: ADDON-62193 encoded the redirect_uri upon opening the popup

### DIFF
--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -494,7 +494,7 @@ class BaseFormView extends PureComponent {
                 let host = encodeURI(
                     `https://${this.datadict.endpoint}${this.oauthConf.authCodeEndpoint}${parameters}`
                 );
-                const redirectURI = host.split('&redirect_uri=')[1].split('&')[0];
+                const redirectURI = new URLSearchParams(host).get('redirect_uri');
                 host = host.replace(redirectURI, encodeURIComponent(redirectURI));
 
                 (async () => {

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -491,9 +491,11 @@ class BaseFormView extends PureComponent {
                     parameters = `${parameters}&scope=${this.datadict.scope}`;
                 }
 
-                const host = encodeURI(
+                let host = encodeURI(
                     `https://${this.datadict.endpoint}${this.oauthConf.authCodeEndpoint}${parameters}`
                 );
+                const redirectURI = host.split('&redirect_uri=')[1].split('&')[0];
+                host = host.replace(redirectURI, encodeURIComponent(redirectURI));
 
                 (async () => {
                     this.isCalled = false;


### PR DESCRIPTION
[ADDON-62193](https://splunk.atlassian.net/browse/ADDON-62193)
* Encoded the redirect_uri value when opening up the popup in the OAuth workflow for asking the user consent

**Reason for the changes:**
* In the Box add-on, we encountered the issue when having the IP address in the redirect_uri, it is throwing the 403 forbidden error for the below type of request.
  * `https://account.box.com/api/oauth2/authorize?response_type=code&client_id=<client_id>&redirect_uri=https://10.0.16.0`
* The above URL was working as expected previously but due to the behavior change at the Box platform for the redirect_uri having the IP address, now it is no longer working.
  * If we encode the redirect_uri then the OAuth workflow would work as expected.
    * `https://account.box.com/api/oauth2/authorize?response_type=code&client_id=<client_id>&redirect_uri=https%3A%2F%2F10.0.16.0`

Tested the changes in the Box, ServiceNow and Salesforce add-on.