### PR TITLE
feat: ADDON-62948 Added support for subTitle field in service

### DIFF
--- a/src/main/webapp/components/CustomMenu.jsx
+++ b/src/main/webapp/components/CustomMenu.jsx
@@ -14,11 +14,14 @@ class CustomMenu extends Component {
     }
 
     componentDidMount() {
-        const globalConfig = getUnifiedConfigs();
+        const unifiedConfigs = getUnifiedConfigs();
+        const { services, menu: customMenuField, groupsMenu } = unifiedConfigs.pages.inputs;
         this.setState({ loading: true });
         this.loadCustomMenu().then((Control) => {
-            const customControl = new Control(globalConfig, this.el, this.setValue);
-            customControl.render();
+            const customControl = new Control(unifiedConfigs, this.el, this.setValue);
+            if (services && customMenuField && !groupsMenu) {
+                customControl.render();
+            }
             this.setState({ loading: false });
         });
     }

--- a/src/main/webapp/components/MenuInput.jsx
+++ b/src/main/webapp/components/MenuInput.jsx
@@ -6,10 +6,18 @@ import Menu from '@splunk/react-ui/Menu';
 import SlidingPanels from '@splunk/react-ui/SlidingPanels';
 import ChevronLeft from '@splunk/react-icons/ChevronLeft';
 import { _ } from '@splunk/ui-utils/i18n';
+import styled from 'styled-components';
+import { variables } from '@splunk/themes';
 import { getFormattedMessage } from '../util/messageUtil';
 import { getUnifiedConfigs } from '../util/util';
 import CustomMenu from './CustomMenu';
 import { StyledButton } from '../pages/EntryPageStyle';
+
+const CustomSubTitle = styled.span`
+    color: ${variables.brandColorD20};
+    font-size: ${variables.fontSizeSmall};
+    font-weight: 500;
+`;
 
 function MenuInput({ handleRequestOpen }) {
     const [activePanelId, setActivePanelId] = useState('main_panel');
@@ -67,6 +75,7 @@ function MenuInput({ handleRequestOpen }) {
                     }}
                 >
                     {service.title}
+                    <CustomSubTitle>&nbsp;{service.subTitle}</CustomSubTitle>
                 </Menu.Item>
             )
         );
@@ -105,13 +114,17 @@ function MenuInput({ handleRequestOpen }) {
                     group.groupServices.forEach((serviceName) => {
                         servicesGroup[group.groupName].push({
                             name: serviceName,
-                            title: services.find((service) => service.name === serviceName).title,
                             hasSubmenu: false,
+                            title: services.find((service) => service.name === serviceName).title,
+                            subTitle: services.find((service) => service.name === serviceName)
+                                .subTitle,
                         });
                     });
                     servicesGroup.main_panel.push({
                         name: group.groupName,
                         title: group.groupTitle,
+                        subTitle: services.find((service) => service.name === group.groupName)
+                            .subTitle,
                         hasSubmenu: true,
                     });
                 } else {
@@ -126,6 +139,7 @@ function MenuInput({ handleRequestOpen }) {
             servicesGroup.main_panel = services.map((service) => ({
                 name: service.name,
                 title: service.title,
+                subTitle: service.subTitle,
                 hasSubmenu: false,
             }));
         }
@@ -143,7 +157,7 @@ function MenuInput({ handleRequestOpen }) {
             <SlidingPanels
                 activePanelId={activePanelId}
                 transition={slidingPanelsTransition}
-                style={{ width: '200px' }}
+                style={{ width: '210px' }}
             >
                 {getInputMenu}
             </SlidingPanels>
@@ -173,8 +187,25 @@ function MenuInput({ handleRequestOpen }) {
         </>
     );
 
+    const getCustomMenuAndGroupsMenu = () => (
+        <>
+            {React.createElement(CustomMenu, {
+                fileName: customMenuField.src,
+                type: customMenuField.type,
+                handleChange: handleChangeCustomMenu,
+            })}
+            {services.length === 1 ? makeInputButton() : makeSingleSelectDropDown()}
+        </>
+    );
+
     if (services && !customMenuField?.src) {
         return services.length === 1 ? makeInputButton() : makeSingleSelectDropDown();
+    }
+
+    // Introducing a condition to enable simultaneous support for custom menu src and Groups Menu.
+    // ADDON-62948
+    if (services && customMenuField?.src && groupsMenu) {
+        return getCustomMenuAndGroupsMenu();
     }
     return makeCustomMenu();
 }

--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -814,6 +814,10 @@
                     "type": "string",
                     "maxLength": 100
                   },
+                  "subTitle": {
+                    "type": "string",
+                    "maxLength": 50
+                  },
                   "entity": {
                     "type": "array",
                     "items": {
@@ -909,6 +913,10 @@
                   "title": {
                     "type": "string",
                     "maxLength": 100
+                  },
+                  "subTitle": {
+                    "type": "string",
+                    "maxLength": 50
                   },
                   "description": {
                     "type": "string",


### PR DESCRIPTION
**Jira Link -** https://splunk.atlassian.net/browse/ADDON-62948

Introduced a new way to add **subTitle** in the service name so it will look like this -

![image (11)](https://github.com/splunk/addonfactory-ucc-base-ui/assets/62089106/ce1c2694-81ea-480f-a790-eeb6bbc483a2)

global config snippet -

> "services": [
                {
                    "entity": [],
                    "name": "box_service",
                    "title": "Historical Querying Inputs",
                    "subTitle": "(Recommended)"
                }
]

Also did a minor modification in the code so that developer can utilise **custom menu** and **groupsMenu** feature together.

> We will raise another PR to update ucc doc accordingly