### PR TITLE
fix: ADDON-61204 Remove support of placeholder property

### DIFF
--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -1063,29 +1063,10 @@ class BaseFormView extends PureComponent {
                         if (this.groupEntities.includes(e.field)) {
                             return null;
                         }
+
                         const temState = this.state.data[e.field];
 
-                        if (temState.placeholder) {
-                            // eslint-disable-next-line no-param-reassign
-                            e = {
-                                ...e,
-                                options: { ...e.options, placeholder: temState.placeholder },
-                            };
-                        }
-
-                        // Add 'optional' placeholder for optional field
-                        // Note: for oauth field it is possible required is false but the field is actually required
-                        // based on what type of authentication is selected
-                        if (
-                            !e.required &&
-                            !Object.prototype.hasOwnProperty.call(e, 'oauth_field') &&
-                            !e.options?.placeholder
-                        ) {
-                            e.options = {
-                                ...e.options,
-                                placeholder: 'optional',
-                            };
-                        }
+                        if (!temState) return null;
 
                         return (
                             <ControlWrapper

--- a/src/main/webapp/components/MultiInputComponent.jsx
+++ b/src/main/webapp/components/MultiInputComponent.jsx
@@ -3,13 +3,17 @@ import PropTypes from 'prop-types';
 import Multiselect from '@splunk/react-ui/Multiselect';
 import styled from 'styled-components';
 import axios from 'axios';
+import WaitSpinner from '@splunk/react-ui/WaitSpinner';
 
 import { axiosCallWrapper } from '../util/axiosCallWrapper';
 import { filterResponse } from '../util/util';
-import { getFormattedMessage } from '../util/messageUtil';
 
 const MultiSelectWrapper = styled(Multiselect)`
     width: 320px !important;
+`;
+
+const WaitSpinnerWrapper = styled(WaitSpinner)`
+    margin-left: 5px;
 `;
 
 function MultiInputComponent(props) {
@@ -29,7 +33,6 @@ function MultiInputComponent(props) {
         items,
         dependencies,
         referenceName,
-        placeholder,
         createSearchChoice,
         labelField,
         delimiter = ',',
@@ -96,23 +99,25 @@ function MultiInputComponent(props) {
     }, [dependencyValues]);
 
     const effectiveDisabled = loading ? true : disabled;
-    const effectivePlaceholder = loading ? getFormattedMessage(115) : placeholder;
+    const loadingIndicator = loading ? <WaitSpinnerWrapper /> : null;
 
     const valueList = value ? value.split(delimiter) : [];
 
     return (
-        <MultiSelectWrapper
-            values={valueList}
-            error={error}
-            name={field}
-            placeholder={effectivePlaceholder}
-            disabled={effectiveDisabled}
-            allowNewValues={createSearchChoice}
-            onChange={handleChange} // eslint-disable-line react/jsx-no-bind
-            inline
-        >
-            {options && options.length > 0 && options}
-        </MultiSelectWrapper>
+        <>
+            <MultiSelectWrapper
+                values={valueList}
+                error={error}
+                name={field}
+                disabled={effectiveDisabled}
+                allowNewValues={createSearchChoice}
+                onChange={handleChange} // eslint-disable-line react/jsx-no-bind
+                inline
+            >
+                {options && options.length > 0 && options}
+            </MultiSelectWrapper>
+            {loadingIndicator}
+        </>
     );
 }
 
@@ -125,7 +130,6 @@ MultiInputComponent.propTypes = {
     dependencyValues: PropTypes.object,
     controlOptions: PropTypes.shape({
         delimiter: PropTypes.string,
-        placeholder: PropTypes.string,
         createSearchChoice: PropTypes.bool,
         referenceName: PropTypes.string,
         dependencies: PropTypes.array,

--- a/src/main/webapp/components/SingleInputComponent.jsx
+++ b/src/main/webapp/components/SingleInputComponent.jsx
@@ -4,15 +4,19 @@ import Select from '@splunk/react-ui/Select';
 import Button from '@splunk/react-ui/Button';
 import ComboBox from '@splunk/react-ui/ComboBox';
 import Clear from '@splunk/react-icons/enterprise/Clear';
-import { _ } from '@splunk/ui-utils/i18n';
 import axios from 'axios';
 import styled from 'styled-components';
+import WaitSpinner from '@splunk/react-ui/WaitSpinner';
 
 import { axiosCallWrapper } from '../util/axiosCallWrapper';
 import { filterResponse } from '../util/util';
 
 const SelectWrapper = styled(Select)`
     width: 320px !important;
+`;
+
+const WaitSpinnerWrapper = styled(WaitSpinner)`
+    margin-left: 5px;
 `;
 
 const StyledDiv = styled.div`
@@ -34,7 +38,6 @@ function SingleInputComponent(props) {
         endpointUrl,
         denyList,
         allowList,
-        placeholder = _('Select a value'),
         dependencies,
         createSearchChoice,
         referenceName,
@@ -120,7 +123,7 @@ function SingleInputComponent(props) {
     }, [dependencyValues]);
 
     const effectiveDisabled = loading ? true : disabled;
-    const effectivePlaceholder = loading ? _('Loading') : placeholder;
+    const loadingIndicator = loading ? <WaitSpinnerWrapper /> : null;
     // hideClearBtn=true only passed for OAuth else its undefined
     // effectiveIsClearable button will be visible only for the required=false and createSearchChoice=false single-select fields.
     const effectiveIsClearable = !(effectiveDisabled || restProps.required || hideClearBtn);
@@ -131,13 +134,13 @@ function SingleInputComponent(props) {
                 value={props.value === null ? '' : props.value}
                 name={field}
                 error={error}
-                placeholder={effectivePlaceholder}
                 disabled={effectiveDisabled}
                 onChange={handleChange} // eslint-disable-line react/jsx-no-bind
                 inline
             >
                 {options && options.length > 0 && options}
             </ComboBox>
+            {loadingIndicator}
         </StyledDiv>
     ) : (
         <>
@@ -147,14 +150,14 @@ function SingleInputComponent(props) {
                 value={props.value}
                 name={field}
                 error={error}
-                placeholder={effectivePlaceholder}
                 disabled={effectiveDisabled}
                 onChange={handleChange} // eslint-disable-line react/jsx-no-bind
                 filter={!disableSearch}
                 inline
             >
                 {options && options.length > 0 && options}
-            </SelectWrapper>
+            </SelectWrapper>{' '}
+            {loadingIndicator}
             {effectiveIsClearable ? (
                 <Button
                     data-test="clear"
@@ -179,7 +182,6 @@ SingleInputComponent.propTypes = {
         endpointUrl: PropTypes.string,
         denyList: PropTypes.string,
         allowList: PropTypes.string,
-        placeholder: PropTypes.string,
         dependencies: PropTypes.array,
         createSearchChoice: PropTypes.bool,
         referenceName: PropTypes.string,

--- a/src/main/webapp/components/TextAreaComponent.jsx
+++ b/src/main/webapp/components/TextAreaComponent.jsx
@@ -17,7 +17,6 @@ function TextAreaComponent(props) {
             inline
             canClear
             error={props.error}
-            placeholder={props?.controlOptions?.placeholder}
             className={props.field}
             disabled={props.disabled}
             value={props.value?.toString() || ''}

--- a/src/main/webapp/components/TextComponent.jsx
+++ b/src/main/webapp/components/TextComponent.jsx
@@ -17,7 +17,6 @@ class TextComponent extends Component {
             <TextWrapper
                 inline
                 error={this.props.error}
-                placeholder={this.props?.controlOptions?.placeholder}
                 className={this.props.field}
                 disabled={this.props.disabled}
                 value={
@@ -38,7 +37,6 @@ TextComponent.propTypes = {
     handleChange: PropTypes.func.isRequired,
     field: PropTypes.string,
     error: PropTypes.bool,
-    controlOptions: PropTypes.object,
     encrypted: PropTypes.bool,
     disabled: PropTypes.bool,
 };

--- a/src/main/webapp/components/table/TableFilter.jsx
+++ b/src/main/webapp/components/table/TableFilter.jsx
@@ -6,14 +6,7 @@ import TableContext from '../../context/TableContext';
 function TableFilter(props) {
     const { searchText } = useContext(TableContext);
 
-    return (
-        <Text
-            appearance="search"
-            placeholder="filter"
-            onChange={props.handleChange}
-            value={searchText}
-        />
-    );
+    return <Text appearance="search" onChange={props.handleChange} value={searchText} />;
 }
 
 TableFilter.propTypes = {

--- a/src/main/webapp/constants/messageDict.ts
+++ b/src/main/webapp/constants/messageDict.ts
@@ -52,7 +52,6 @@ export default {
     112: 'email address',
     113: 'IPV4 address',
     114: 'date in ISO 8601 format',
-    115: 'Loading',
     // Page title
     116: 'Inputs',
     117: 'Configuration',


### PR DESCRIPTION
**Jira Link -** https://splunk.atlassian.net/browse/ADDON-61204

We have deprecated support for the "placeholder" attribute (as announced by Splunk UI.) It won't be breaking change.

Users can still use the "placeholder" property in the global config file, but it won't have any impact on the UI. As a result, the placeholder will not be visible anymore. Instead of that, we recommend using the [help](https://splunk.github.io/addonfactory-ucc-generator/entity/) property to display any additional message along with the component.

Slack thread link for ref - https://splunk.slack.com/archives/C8R00E97S/p1689831102691599