### PR TITLE
chore(deps): ADDON-64842 fix CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,18 @@
     "prepare": "husky install"
   },
   "dependencies": {
+    "@splunk/react-icons": "^4.0.1",
     "@splunk/react-page": "^6.0.3",
     "@splunk/react-toast-notifications": "^0.11.1",
     "@splunk/react-ui": "^4.16.0",
     "@splunk/splunk-utils": "^2.3.0",
     "@splunk/themes": "^0.14.0",
+    "@splunk/ui-utils": "^1.5.2",
     "axios": "^1.2.3",
     "immutability-helper": "^3.1.1",
     "license-webpack-plugin": "^4.0.2",
+    "lodash": "^4.17.21",
+    "prop-types": "^15.8.1",
     "react": "^16.9.38",
     "react-dom": "^16.9.8",
     "react-router-dom": "^6.7.0",
@@ -60,6 +64,7 @@
     "husky": "^8.0.3",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
+    "js-yaml": "^4.1.0",
     "lint-staged": "^13.1.0",
     "prettier": "^2.8.3",
     "semantic-release": "^19.0.5",
@@ -80,10 +85,11 @@
     ]
   },
   "resolutions": {
-    "glob-parent": "^5.1.2",
+    "@npmcli/git": "^2.0.8",
     "css-what": "^5.0.1",
+    "glob-parent": "^5.1.2",
     "postcss": "^8.2.10",
-    "@npmcli/git": "^2.0.8"
+    "semver": "^7.5.2"
   },
   "engines": {
     "node": ">=14.21.2"

--- a/src/main/webapp/components/ErrorBoundary.jsx
+++ b/src/main/webapp/components/ErrorBoundary.jsx
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import Heading from '@splunk/react-ui/Heading';
 import { _ } from '@splunk/ui-utils/i18n';
 import Card from '@splunk/react-ui/Card';
-import WarningIcon from '@splunk/react-icons/Warning';
+import WarningIcon from '@splunk/react-icons/enterprise/Warning';
 import errorCodes from '../constants/errorCodes';
 
 class ErrorBoundary extends React.Component {

--- a/src/main/webapp/components/SingleInputComponent.jsx
+++ b/src/main/webapp/components/SingleInputComponent.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Select from '@splunk/react-ui/Select';
 import Button from '@splunk/react-ui/Button';
 import ComboBox from '@splunk/react-ui/ComboBox';
-import Clear from '@splunk/react-icons/Clear';
+import Clear from '@splunk/react-icons/enterprise/Clear';
 import { _ } from '@splunk/ui-utils/i18n';
 import axios from 'axios';
 import styled from 'styled-components';

--- a/src/main/webapp/components/table/CustomTableRow.jsx
+++ b/src/main/webapp/components/table/CustomTableRow.jsx
@@ -7,8 +7,8 @@ import Table from '@splunk/react-ui/Table';
 import ButtonGroup from '@splunk/react-ui/ButtonGroup';
 import Tooltip from '@splunk/react-ui/Tooltip';
 import Pencil from '@splunk/react-icons/Pencil';
-import Clone from '@splunk/react-icons/Clone';
-import Trash from '@splunk/react-icons/Trash';
+import Clone from '@splunk/react-icons/enterprise/Clone';
+import Trash from '@splunk/react-icons/enterprise/Trash';
 import styled from 'styled-components';
 import { _ } from '@splunk/ui-utils/i18n';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1920,6 +1920,19 @@
     lodash "^4.17.14"
     prop-types "^15.6.2"
 
+"@splunk/react-icons@^4.0.1":
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/@splunk/react-icons/-/react-icons-4.0.1.tgz#ccf103a7f6717c2ebfd1feea3831e47eeeb9e756"
+  integrity sha512-WJ7DgL9AoDQL5mQ28D3KtKjhdFpvKMsvxk2Olg6HVn3nP1ePfDb1QtIOjLIN6+AvKyDKQPrnlFkLy38sw2ErJA==
+  dependencies:
+    "@splunk/ui-utils" "^1.6.0"
+    "@types/lodash" "^4.14.156"
+    "@types/react" "^16.9.38"
+    "@types/react-dom" "^16.9.8"
+    "@types/styled-components" "^5.1.0"
+    lodash "^4.17.14"
+    prop-types "^15.6.2"
+
 "@splunk/react-page@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@splunk/react-page/-/react-page-6.0.3.tgz#31cb1903610643a15a99b5c3c1af5149f67b97c4"
@@ -2025,6 +2038,14 @@
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@splunk/ui-utils/-/ui-utils-1.5.2.tgz#2108fd8d4e0937bc9ed9f81d6ac92821f57391e0"
   integrity sha512-kOUM13GxMybYxZkiibT8MhtIYfAA4ub0MxyC50rJSSADGv7aq+QRNh7N/zHF9ov8Ir7EpNUDlKxxOtuAkCKTtw==
+  dependencies:
+    keycode "^2.1.9"
+    lodash "^4.17.21"
+
+"@splunk/ui-utils@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@splunk/ui-utils/-/ui-utils-1.6.0.tgz#66576bdf80830fb0ec8b0f9e48031ce61eb54e7c"
+  integrity sha512-6uMStGhXno5LluvKZtO34K1LO50T6m9hgoC2FvQ5KEtFLz1MID8XkW3vLjh4zcxU/7ntgQBAlteBLRqi38AF7A==
   dependencies:
     keycode "^2.1.9"
     lodash "^4.17.21"
@@ -8104,20 +8125,10 @@ semver-regex@^3.1.2:
   resolved "https://registry.yarnpkg.com/semver-regex/-/semver-regex-3.1.4.tgz#13053c0d4aa11d070a2f2872b6b1e3ae1e1971b4"
   integrity sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==
 
-"semver@2 || 3 || 4 || 5":
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
-  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
-
-semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
-  integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
-
-semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8:
-  version "7.3.8"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
-  integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==
+"semver@2 || 3 || 4 || 5", semver@^6.0.0, semver@^6.1.1, semver@^6.1.2, semver@^6.3.0, semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2:
+  version "7.5.4"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.5.4.tgz#483986ec4ed38e1c6c48c34894a9182dbff68a6e"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
JIRA Link - https://splunk.atlassian.net/browse/ADDON-64842

- added missing dependencies to package.json that were installed transitive. 
- added missing direct dependency react-icon (how did it work before?)
- fixed paths that changed since v3 for react-icons
- fixed vulnerability CVE-2022-25883 fossa was complaining about

<img width="2559" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/e25c714e-d8d8-4241-b296-545bb29dc4a4">
