### PR TITLE
test: ADDON-64637 add tests for InputPage and MenuInput

### DIFF
--- a/src/main/webapp/components/MenuInput.test.jsx
+++ b/src/main/webapp/components/MenuInput.test.jsx
@@ -1,0 +1,276 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import * as React from 'react';
+import userEvent from '@testing-library/user-event';
+import { AnimationToggleProvider } from '@splunk/react-ui/AnimationToggle';
+import MenuInput from './MenuInput';
+import { mockCustomMenu } from '../tests/helpers';
+import { getUnifiedConfigs } from '../util/util';
+
+jest.mock('../util/util');
+
+// for further TS support
+// const getUnifiedConfigsMock = getUnifiedConfigs as jest.Mock;
+let mockCustomMenuInstance;
+
+beforeEach(() => {
+    mockCustomMenuInstance = mockCustomMenu().mockCustomMenuInstance;
+});
+
+function setup(inputs) {
+    const mockHandleRequestOpen = jest.fn();
+    getUnifiedConfigs.mockImplementation(() => ({
+        pages: {
+            inputs,
+        },
+        meta: {},
+    }));
+    render(
+        <AnimationToggleProvider enabled={false}>
+            <MenuInput handleRequestOpen={mockHandleRequestOpen} />
+        </AnimationToggleProvider>
+    );
+    return { mockHandleRequestOpen };
+}
+
+function getCreateButton() {
+    return screen.getByRole('button', { name: 'Create New Input' });
+}
+
+describe('single service', () => {
+    function getOneService() {
+        return [
+            {
+                name: 'test-service-name',
+                title: 'test-service-title',
+                subTitle: 'test-service-subTitle',
+            },
+        ];
+    }
+
+    it('should render button Create New Input', async () => {
+        setup({ services: getOneService() });
+        const createButton = getCreateButton();
+
+        expect(createButton).toBeInTheDocument();
+        expect(createButton).toHaveAttribute('data-test', 'button');
+    });
+
+    it('should call callback with service name on user click', async () => {
+        const { mockHandleRequestOpen } = setup({ services: getOneService() });
+        const createButton = getCreateButton();
+
+        await userEvent.click(createButton);
+
+        expect(mockHandleRequestOpen).toHaveBeenCalledWith('test-service-name');
+    });
+});
+
+describe('multiple services', () => {
+    function getTwoServices() {
+        return [
+            {
+                name: 'test-service-name1',
+                title: 'test-service-title1',
+                subTitle: 'test-service-subTitle1',
+            },
+            {
+                name: 'test-service-name2',
+                title: 'test-service-title2',
+                subTitle: 'test-service-subTitle2',
+            },
+        ];
+    }
+
+    function getCreateDropdown() {
+        return screen.getByRole('button', { name: 'Create New Input' });
+    }
+
+    it('should render dropdown Create New Input', async () => {
+        setup({ services: getTwoServices() });
+        const createDropdown = getCreateDropdown();
+        expect(createDropdown).toBeInTheDocument();
+        expect(createDropdown).toHaveAttribute('data-test', 'dropdown');
+    });
+
+    it('should render service menu items on opening dropdown', async () => {
+        setup({ services: getTwoServices() });
+        await userEvent.click(getCreateDropdown());
+        expect(screen.getByTestId('menu')).toBeInTheDocument();
+        expect(screen.getAllByTestId('item')).toHaveLength(2);
+        expect(screen.getByText('test-service-title1')).toBeInTheDocument();
+        expect(screen.getByText('test-service-subTitle2')).toBeInTheDocument();
+    });
+
+    it('should call callback with service name and default group name (main_panel) on menu item click', async () => {
+        const { mockHandleRequestOpen } = setup({ services: getTwoServices() });
+        await userEvent.click(getCreateDropdown());
+        await userEvent.click(screen.getByText('test-service-title2'));
+        expect(mockHandleRequestOpen).toHaveBeenCalledWith('test-service-name2', 'main_panel');
+    });
+
+    describe('groups', () => {
+        function getGroupedServices() {
+            return {
+                services: [
+                    {
+                        name: 'test-service-name1',
+                        title: 'test-service-title1',
+                        subTitle: 'test-service-subTitle1',
+                        hasSubmenu: true,
+                    },
+                    {
+                        name: 'test-subservice1-name1',
+                        title: 'test-subservice1-title1',
+                        subTitle: 'test-subservice-subTitle1',
+                    },
+                    {
+                        name: 'test-subservice1-name2',
+                        title: 'test-subservice1-title2',
+                        subTitle: 'test-subservice-subTitle2',
+                    },
+                    {
+                        name: 'test-service-name2',
+                        title: 'test-service-title2',
+                        subTitle: 'test-service-subTitle2',
+                    },
+                ],
+                groupsMenu: [
+                    {
+                        groupName: 'test-group-name1',
+                        groupTitle: 'test-group-title1',
+                        groupServices: ['test-subservice1-name1', 'test-subservice1-name2'],
+                    },
+                ],
+            };
+        }
+
+        it('should render group title', async () => {
+            setup(getGroupedServices());
+            await userEvent.click(getCreateDropdown());
+            expect(screen.getByText('test-group-title1')).toBeInTheDocument();
+            expect(screen.getByText('test-group-title1')).not.toHaveAttribute('aria-haspopup');
+        });
+
+        it('should render group items', async () => {
+            setup(getGroupedServices());
+            // open dropdown
+            await userEvent.click(getCreateDropdown());
+            // check sub menu is not rendered
+            expect(screen.queryByText('test-subservice1-title1')).not.toBeInTheDocument();
+            expect(screen.queryByText('test-subservice-subTitle2')).not.toBeInTheDocument();
+            // click on group title
+            await userEvent.click(screen.getByText('test-group-title1'));
+            // check sub menu is rendered
+            expect(screen.queryByText('test-subservice1-title1')).toBeInTheDocument();
+            expect(screen.queryByText('test-subservice-subTitle2')).toBeInTheDocument();
+            expect(screen.queryByText('test-group-title1')).not.toBeInTheDocument();
+
+            await userEvent.click(screen.getByRole('menuitem', { name: 'Back' }));
+            await waitFor(() =>
+                expect(screen.queryByText('test-subservice-subTitle1')).not.toBeInTheDocument()
+            );
+            expect(screen.queryByText('test-group-title1')).toBeInTheDocument();
+        });
+
+        it('should render group as menu item if no underlying services', async () => {
+            setup({
+                ...getGroupedServices(),
+                groupsMenu: [{ groupName: 'test-group-name1', groupTitle: 'test-group-title1' }],
+            });
+            await userEvent.click(getCreateDropdown());
+            // await userEvent.click(screen.getByText('test-group-title1'));
+            expect(screen.getByText('test-group-title1')).toBeInTheDocument();
+            expect(screen.getByText('test-group-title1')).not.toHaveAttribute('aria-haspopup');
+        });
+
+        it('should call handleRequestOpen callback on click', async () => {
+            const { mockHandleRequestOpen } = setup(getGroupedServices());
+            await userEvent.click(getCreateDropdown());
+
+            await userEvent.click(screen.getByText('test-group-title1'));
+            await userEvent.click(screen.getByText('test-subservice1-title1'));
+
+            expect(mockHandleRequestOpen).toHaveBeenCalledWith(
+                'test-subservice1-name1',
+                'test-group-name1'
+            );
+        });
+    });
+
+    describe('menu', () => {
+        it('should render CustomMenu wrapper with groupsMenu without rendering underlying custom component', async () => {
+            setup({
+                services: [
+                    {
+                        name: 'test-service-name1',
+                        title: 'test-service-title1',
+                        subTitle: 'test-service-subTitle1',
+                        hasSubmenu: true,
+                    },
+                    {
+                        name: 'test-subservice1-name1',
+                        title: 'test-subservice1-title1',
+                        subTitle: 'test-subservice-subTitle1',
+                    },
+                    {
+                        name: 'test-subservice1-name2',
+                        title: 'test-subservice1-title2',
+                        subTitle: 'test-subservice-subTitle2',
+                    },
+                    {
+                        name: 'test-service-name2',
+                        title: 'test-service-title2',
+                        subTitle: 'test-service-subTitle2',
+                    },
+                ],
+                menu: {
+                    src: 'CustomMenu',
+                    type: 'external',
+                },
+                groupsMenu: [
+                    {
+                        groupName: 'test-group-name1',
+                        groupTitle: 'test-group-title1',
+                        groupServices: ['test-subservice1-name1', 'test-subservice1-name2'],
+                    },
+                ],
+            });
+            // the loading indicator from CustomMenu component
+            const loadingEl = screen.getByText('Loading...');
+            expect(loadingEl).toBeInTheDocument();
+            await waitFor(() => expect(loadingEl).not.toHaveTextContent('Loading...'));
+
+            const createNewInputBtn = screen.queryByRole('button', { name: 'Create New Input' });
+
+            expect(createNewInputBtn).toBeInTheDocument();
+            // that's weird
+            expect(mockCustomMenuInstance.render).not.toHaveBeenCalled();
+        });
+
+        it('should render CustomMenu wrapper without groupsMenu without rendering underlying custom component', async () => {
+            setup({
+                services: [
+                    {
+                        name: 'test-service-name1',
+                        title: 'test-service-title1',
+                    },
+                ],
+                menu: {
+                    src: 'CustomMenu',
+                    type: 'external',
+                },
+            });
+
+            // the loading indicator is from CustomMenu component
+            const loadingEl = screen.getByText('Loading...');
+            expect(loadingEl).toBeInTheDocument();
+            await waitFor(() => expect(loadingEl).not.toHaveTextContent('Loading...'));
+
+            // that's weird
+            expect(mockCustomMenuInstance.render).toHaveBeenCalled();
+            const createNewInputBtn = screen.queryByRole('button', { name: 'Create New Input' });
+            // that's also weird
+            expect(createNewInputBtn).not.toBeInTheDocument();
+        });
+    });
+});

--- a/src/main/webapp/components/MenuInput.test.jsx
+++ b/src/main/webapp/components/MenuInput.test.jsx
@@ -266,10 +266,8 @@ describe('multiple services', () => {
             expect(loadingEl).toBeInTheDocument();
             await waitFor(() => expect(loadingEl).not.toHaveTextContent('Loading...'));
 
-            // that's weird
             expect(mockCustomMenuInstance.render).toHaveBeenCalled();
             const createNewInputBtn = screen.queryByRole('button', { name: 'Create New Input' });
-            // that's also weird
             expect(createNewInputBtn).not.toBeInTheDocument();
         });
     });

--- a/src/main/webapp/pages/Input/InputPage.test.jsx
+++ b/src/main/webapp/pages/Input/InputPage.test.jsx
@@ -1,0 +1,45 @@
+import * as React from 'react';
+import { render, screen, waitForElementToBeRemoved, act } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+
+import InputPage from './InputPage';
+import { mockCustomMenu } from '../../tests/helpers';
+
+const mockNavigateFn = jest.fn();
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockNavigateFn,
+}));
+
+jest.mock('../../util/util');
+
+let mockCustomMenuInstance;
+
+beforeEach(() => {
+    mockCustomMenuInstance = mockCustomMenu().mockCustomMenuInstance;
+});
+
+it('should redirect user on menu click', async () => {
+    render(<InputPage />, { wrapper: BrowserRouter });
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
+
+    expect(mockNavigateFn).not.toHaveBeenCalled();
+
+    const service = 'aws_billing_cur';
+    const action = 'create';
+    const input = 'test-input';
+    act(() =>
+        // emulate user click on third-party menu component
+        mockCustomMenuInstance.navigator({
+            service,
+            action,
+            input,
+        })
+    );
+
+    // check that InputPage redirects to correct URL according to callback
+    expect(mockNavigateFn).toHaveBeenCalledWith({
+        search: `service=${service}&action=${action}`,
+    });
+});

--- a/src/main/webapp/tests/helpers.js
+++ b/src/main/webapp/tests/helpers.js
@@ -1,0 +1,26 @@
+export function mockCustomMenu() {
+    jest.resetModules();
+    class MockCustomRenderable {
+        navigator;
+
+        render = jest.fn().mockReturnValue(undefined);
+    }
+
+    const mockCustomMenuInstance = new MockCustomRenderable();
+    jest.mock(
+        '/custom/CustomMenu.js',
+        () => (globalConfig, target, navigator) => {
+            mockCustomMenuInstance.navigator = navigator;
+            return mockCustomMenuInstance;
+        },
+        { virtual: true }
+    );
+    jest.mock('/custom/Hook.js', () => () => {}, { virtual: true });
+    jest.mock('/custom/PrivateEndpointInput.js', () => () => new MockCustomRenderable(), {
+        virtual: true,
+    });
+
+    return {
+        mockCustomMenuInstance,
+    };
+}

--- a/src/main/webapp/util/__mocks__/mockUnifiedConfig.js
+++ b/src/main/webapp/util/__mocks__/mockUnifiedConfig.js
@@ -1,0 +1,177 @@
+import { MOCKED_TA_INPUT } from '../../mocks/server-response';
+
+export const mockUnifiedConfig = {
+    meta: {
+        restRoot: 'restRoot',
+    },
+    pages: {
+        inputs: {
+            title: 'Inputs',
+            description: 'Create data inputs to collect data from AWS',
+            table: {
+                header: [
+                    {
+                        field: 'name',
+                        label: 'Input Name',
+                        customCell: {
+                            src: 'CustomInputCell',
+                            type: 'external',
+                        },
+                    },
+                ],
+                moreInfo: [
+                    {
+                        field: 'name',
+                        label: 'Name',
+                    },
+                ],
+                customRow: {
+                    src: 'CustomInputRow',
+                    type: 'external',
+                },
+                actions: ['edit', 'delete', 'clone'],
+            },
+            menu: {
+                src: 'CustomMenu',
+                type: 'external',
+            },
+            services: [
+                {
+                    name: 'aws_billing_cur',
+                    title: 'Billing (Cost and Usage Report)',
+                    style: 'page',
+                    hook: {
+                        src: 'Hook',
+                        type: 'external',
+                    },
+                    restHandlerName: 'aws_billing_cur_inputs_rh',
+                    groups: [
+                        {
+                            label: 'AWS Input Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: [
+                                'name',
+                                'aws_account',
+                                'aws_iam_role',
+                                'aws_s3_region',
+                                'private_endpoint_enabled',
+                                's3_private_endpoint_url',
+                                'sts_private_endpoint_url',
+                                'bucket_name',
+                                'report_prefix',
+                                'report_names',
+                            ],
+                        },
+                        {
+                            label: 'Splunk-related Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: ['start_date', 'sourcetype', 'index'],
+                        },
+                        {
+                            label: 'Advanced Settings',
+                            options: {
+                                expand: false,
+                                isExpandable: true,
+                            },
+                            fields: ['interval', 'temp_folder'],
+                        },
+                    ],
+                    entity: [
+                        {
+                            field: 'name',
+                            label: 'Name',
+                            type: 'text',
+                            required: true,
+                            options: {
+                                placeholder: 'Required',
+                            },
+                            validators: [
+                                {
+                                    type: 'regex',
+                                    pattern: '^[^%<>/\\^$]+$',
+                                    errorMsg:
+                                        'Please enter name without special characters ^%<>/\\^$',
+                                },
+                            ],
+                        },
+                        {
+                            field: 'aws_account',
+                            label: 'AWS Account',
+                            type: 'singleSelect',
+                            required: true,
+                            options: {
+                                placeholder: 'Select an account',
+                                endpointUrl: MOCKED_TA_INPUT,
+                            },
+                        },
+                    ],
+                },
+                {
+                    name: 'aws_billing',
+                    title: 'Billing (Legacy)',
+                    style: 'page',
+                    hook: {
+                        src: 'Hook',
+                        type: 'external',
+                    },
+                    restHandlerName: 'aws_billing_inputs_rh',
+                    groups: [
+                        {
+                            label: 'AWS Input Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: [
+                                'name',
+                                'aws_account',
+                                'aws_iam_role',
+                                'aws_s3_region',
+                                'bucket_name',
+                                'monthly_report_type',
+                                'detail_report_type',
+                            ],
+                        },
+                        {
+                            label: 'Splunk-related Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: ['initial_scan_datetime', 'sourcetype', 'index'],
+                        },
+                        {
+                            label: 'Advanced Settings',
+                            options: {
+                                expand: false,
+                                isExpandable: true,
+                            },
+                            fields: ['interval', 'report_file_match_reg', 'temp_folder'],
+                        },
+                    ],
+                    entity: [
+                        {
+                            field: 'name',
+                            label: 'Name',
+                            type: 'text',
+                            required: true,
+                            options: {
+                                placeholder: 'Required',
+                            },
+                            validators: [
+                                {
+                                    type: 'regex',
+                                    pattern: '^[^%<>/\\^$]+$',
+                                    errorMsg:
+                                        'Please enter name without special characters ^%<>/\\^$',
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+};

--- a/src/main/webapp/util/__mocks__/util.js
+++ b/src/main/webapp/util/__mocks__/util.js
@@ -1,0 +1,7 @@
+import { mockUnifiedConfig } from './mockUnifiedConfig';
+
+export const generateEndPointUrl = jest.fn(() => 'mockGeneratedEndPointUrl');
+
+export const getUnifiedConfigs = jest.fn().mockImplementation(() => mockUnifiedConfig);
+
+export const generateToast = jest.fn();


### PR DESCRIPTION
The JIRA link - https://splunk.atlassian.net/browse/ADDON-64637

Added unit/integration tests MenuInput and InputPage components.

I have question about the following functionality:
[CustomMenu.jsx:22](https://github.com/splunk/addonfactory-ucc-base-ui/blob/f40b95de8aa868cf3bdb87208eb0827d93753ee7/src/main/webapp/components/CustomMenu.jsx#L22)
```ts
if (services && customMenuField && !groupsMenu) {
    customControl.render();
}
```
we don't render custom component if we don't have groupsMenu.

It is covered with test: `should render CustomMenu wrapper with groupsMenu without rendering underlying custom component`