### PR TITLE
fix: ADDON-64637 add input value to query for menu navigation

### DIFF
--- a/src/main/webapp/components/MenuInput.jsx
+++ b/src/main/webapp/components/MenuInput.jsx
@@ -49,8 +49,8 @@ function MenuInput({ handleRequestOpen }) {
     };
 
     const handleChangeCustomMenu = (val) => {
-        const { service } = val;
-        handleRequestOpen(service);
+        const { service, input } = val;
+        handleRequestOpen({ serviceName: service, input });
     };
 
     const getMenuItems = (serviceItems, groupName) =>
@@ -70,7 +70,7 @@ function MenuInput({ handleRequestOpen }) {
                 <Menu.Item
                     key={service.name}
                     onClick={() => {
-                        handleRequestOpen(service.name, groupName);
+                        handleRequestOpen({ serviceName: service.name, groupName });
                         setIsSubMenu(false);
                     }}
                 >
@@ -171,7 +171,7 @@ function MenuInput({ handleRequestOpen }) {
             appearance="primary"
             id="addInputBtn"
             onClick={() => {
-                handleRequestOpen(services[0].name);
+                handleRequestOpen({ serviceName: services[0].name });
             }}
         />
     );

--- a/src/main/webapp/components/MenuInput.test.jsx
+++ b/src/main/webapp/components/MenuInput.test.jsx
@@ -61,7 +61,7 @@ describe('single service', () => {
 
         await userEvent.click(createButton);
 
-        expect(mockHandleRequestOpen).toHaveBeenCalledWith('test-service-name');
+        expect(mockHandleRequestOpen).toHaveBeenCalledWith({ serviceName: 'test-service-name' });
     });
 });
 
@@ -105,7 +105,10 @@ describe('multiple services', () => {
         const { mockHandleRequestOpen } = setup({ services: getTwoServices() });
         await userEvent.click(getCreateDropdown());
         await userEvent.click(screen.getByText('test-service-title2'));
-        expect(mockHandleRequestOpen).toHaveBeenCalledWith('test-service-name2', 'main_panel');
+        expect(mockHandleRequestOpen).toHaveBeenCalledWith({
+            groupName: 'main_panel',
+            serviceName: 'test-service-name2',
+        });
     });
 
     describe('groups', () => {
@@ -190,10 +193,10 @@ describe('multiple services', () => {
             await userEvent.click(screen.getByText('test-group-title1'));
             await userEvent.click(screen.getByText('test-subservice1-title1'));
 
-            expect(mockHandleRequestOpen).toHaveBeenCalledWith(
-                'test-subservice1-name1',
-                'test-group-name1'
-            );
+            expect(mockHandleRequestOpen).toHaveBeenCalledWith({
+                groupName: 'test-group-name1',
+                serviceName: 'test-subservice1-name1',
+            });
         });
     });
 

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -118,7 +118,11 @@ function InputPage() {
             // set query and push to navigate
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
-            query.set('input', input);
+            if (input) {
+                query.set('input', input);
+            } else {
+                query.delete('input');
+            }
             navigate({ search: query.toString() });
         }
     };

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -100,7 +100,7 @@ function InputPage() {
     };
 
     // handle modal/page open request on create/add entity button
-    const handleRequestOpen = (serviceName, groupName) => {
+    const handleRequestOpen = ({ serviceName, groupName, input }) => {
         const service = services.find((x) => x.name === serviceName);
         const serviceTitle = service.title;
         const isInputPageStyle = service.style === STYLE_PAGE;
@@ -118,6 +118,9 @@ function InputPage() {
             // set query and push to navigate
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
+            if (input) {
+                query.set('input', input);
+            }
             navigate({ search: query.toString() });
         }
     };

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -118,9 +118,7 @@ function InputPage() {
             // set query and push to navigate
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
-            if (input) {
-                query.set('input', input);
-            }
+            query.set('input', input);
             navigate({ search: query.toString() });
         }
     };

--- a/src/main/webapp/pages/Input/InputPage.test.jsx
+++ b/src/main/webapp/pages/Input/InputPage.test.jsx
@@ -40,6 +40,6 @@ it('should redirect user on menu click', async () => {
 
     // check that InputPage redirects to correct URL according to callback
     expect(mockNavigateFn).toHaveBeenCalledWith({
-        search: `service=${service}&action=${action}`,
+        search: `service=${service}&action=${action}&input=${input}`,
     });
 });


### PR DESCRIPTION
The JIRA Link: [ADDON-64637](https://splunk.atlassian.net/browse/ADDON-64637)

I have changed the argument of `handleRequestOpen` prop of MenuInput from
```ts
handleRequestOpen(serviceName: string, groupName: string);
```
to
```ts
handleRequestOpen(params: { serviceName: string, groupName?: string, input?: string });
```

The input value is required in InputPage component for setting URL QueryParam

### input with group
<img width="223" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/eb02c47b-5ebe-45e0-bbce-df73249be90c">
<img width="231" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/930e9713-5a9b-4db8-af5a-62a7c81c38eb">
 
<img width="1055" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/b821bf2b-58e0-420d-9197-b1d30351aae4">

### input without group
<img width="808" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/4ef9fb44-0aca-4731-a161-39514698187f">
