### PR TITLE
ci(build-test-release.yml): replace deprecated set-output command

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)


### PR DESCRIPTION
[GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

Before
<img width="775" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/3b826998-d401-465b-98bd-065f5a168bd4">

After
<img width="781" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/0474810b-b649-48f4-bfcd-47d9997bc057">
