### PR TITLE
chore(BaseFormView): fix exposing sensitive info in stack traces

### DIFF
--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -49,6 +49,14 @@ const CustomGroupLabel = styled.div`
     font-size: 16px;
 `;
 
+function onCustomHookError(params) {
+    const docURL = `https://splunk.github.io/addonfactory-ucc-generator/custom_ui_extensions/custom_hook/`;
+    // eslint-disable-next-line no-console
+    console.error(
+        `[Custom Hook] Something went wrong while calling ${params.methodName}. Please refer to docs or file an issue. ${docURL}`
+    );
+}
+
 class BaseFormView extends PureComponent {
     static contextType = TableContext;
 
@@ -376,8 +384,7 @@ class BaseFormView extends PureComponent {
                     try {
                         this.hook.onCreate();
                     } catch (err) {
-                        // eslint-disable-next-line no-console
-                        console.error(err);
+                        onCustomHookError({ methodName: 'onCreate' });
                     }
                 }
             });
@@ -1026,8 +1033,7 @@ class BaseFormView extends PureComponent {
                         try {
                             this.hook.onRender();
                         } catch (err) {
-                            // eslint-disable-next-line no-console
-                            console.error(err);
+                            onCustomHookError({ methodName: 'onRender' });
                         }
                     }
                 });
@@ -1040,8 +1046,7 @@ class BaseFormView extends PureComponent {
                             try {
                                 this.hook.onEditLoad();
                             } catch (err) {
-                                // eslint-disable-next-line no-console
-                                console.error(err);
+                                onCustomHookError({ methodName: 'onEditLoad' });
                             }
                         }
                     });

--- a/src/main/webapp/components/BaseFormView.jsx
+++ b/src/main/webapp/components/BaseFormView.jsx
@@ -50,10 +50,9 @@ const CustomGroupLabel = styled.div`
 `;
 
 function onCustomHookError(params) {
-    const docURL = `https://splunk.github.io/addonfactory-ucc-generator/custom_ui_extensions/custom_hook/`;
     // eslint-disable-next-line no-console
     console.error(
-        `[Custom Hook] Something went wrong while calling ${params.methodName}. Please refer to docs or file an issue. ${docURL}`
+        `[Custom Hook] Something went wrong while calling ${params.methodName}. Error: ${params.error?.name} ${params.error?.message}`
     );
 }
 
@@ -383,8 +382,8 @@ class BaseFormView extends PureComponent {
                 if (typeof this.hook.onCreate === 'function') {
                     try {
                         this.hook.onCreate();
-                    } catch (err) {
-                        onCustomHookError({ methodName: 'onCreate' });
+                    } catch (error) {
+                        onCustomHookError({ methodName: 'onCreate', error });
                     }
                 }
             });
@@ -1032,8 +1031,8 @@ class BaseFormView extends PureComponent {
                     if (typeof this.hook.onRender === 'function') {
                         try {
                             this.hook.onRender();
-                        } catch (err) {
-                            onCustomHookError({ methodName: 'onRender' });
+                        } catch (error) {
+                            onCustomHookError({ methodName: 'onRender', error });
                         }
                     }
                 });
@@ -1045,8 +1044,8 @@ class BaseFormView extends PureComponent {
                         if (typeof this.hook.onEditLoad === 'function') {
                             try {
                                 this.hook.onEditLoad();
-                            } catch (err) {
-                                onCustomHookError({ methodName: 'onEditLoad' });
+                            } catch (error) {
+                                onCustomHookError({ methodName: 'onEditLoad', error });
                             }
                         }
                     });

--- a/src/main/webapp/components/table/CustomTableControl.jsx
+++ b/src/main/webapp/components/table/CustomTableControl.jsx
@@ -6,10 +6,9 @@ import { getUnifiedConfigs } from '../../util/util';
 import { getBuildDirPath } from '../../util/script';
 
 function onCustomControlError(params) {
-    const docURL = `https://splunk.github.io/addonfactory-ucc-generator/custom_ui_extensions/custom_hook/`;
     // eslint-disable-next-line no-console
     console.error(
-        `[Custom Control] Something went wrong while calling ${params.methodName}. Please refer to docs or file an issue. ${docURL}`
+        `[Custom Control] Something went wrong while calling ${params.methodName}. Error: ${params.error?.name} ${params.error?.message}`
     );
 }
 
@@ -73,8 +72,8 @@ class CustomTableControl extends Component {
         if (!this.state.loading) {
             try {
                 this.customControl.render(this.props.row, this.props.field);
-            } catch (err) {
-                onCustomControlError({ methodName: 'render' });
+            } catch (error) {
+                onCustomControlError({ methodName: 'render', error });
             }
         }
         return (

--- a/src/main/webapp/components/table/CustomTableControl.jsx
+++ b/src/main/webapp/components/table/CustomTableControl.jsx
@@ -5,6 +5,14 @@ import { _ } from '@splunk/ui-utils/i18n';
 import { getUnifiedConfigs } from '../../util/util';
 import { getBuildDirPath } from '../../util/script';
 
+function onCustomControlError(params) {
+    const docURL = `https://splunk.github.io/addonfactory-ucc-generator/custom_ui_extensions/custom_hook/`;
+    // eslint-disable-next-line no-console
+    console.error(
+        `[Custom Control] Something went wrong while calling ${params.methodName}. Please refer to docs or file an issue. ${docURL}`
+    );
+}
+
 class CustomTableControl extends Component {
     constructor(props) {
         super(props);
@@ -66,8 +74,7 @@ class CustomTableControl extends Component {
             try {
                 this.customControl.render(this.props.row, this.props.field);
             } catch (err) {
-                // eslint-disable-next-line no-console
-                console.error(err);
+                onCustomControlError({ methodName: 'render' });
             }
         }
         return (


### PR DESCRIPTION
Addressing the issue found by [security-sast-semgrep](https://github.com/splunk/addonfactory-ucc-base-ui/actions/runs/6038233137/job/16384170975)