### PR TITLE
ci: add job for running ci tests

### DIFF
--- a/.addonmatrix
+++ b/.addonmatrix
@@ -1,0 +1,1 @@
+--splunkfeatures METRICS_MULTI,PYTHON3

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -11,6 +11,14 @@ on:
     branches: [main, develop, "release/**"]
 
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix_supportedSplunk: ${{ steps.matrix.outputs.supportedSplunk }}
+    steps:
+      - uses: actions/checkout@v3
+      - id: matrix
+        uses: splunk/addonfactory-test-matrix-action@v1
   fossa-scan:
     continue-on-error: true
     runs-on: ubuntu-latest
@@ -115,3 +123,60 @@ jobs:
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
+
+  test-ui:
+    name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}
+    if: |
+      github.base_ref == 'main' ||
+      github.ref_name == 'main' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    needs:
+      - meta
+      - build
+    strategy:
+      matrix:
+        splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
+        test-mark:
+          - "logging"
+          - "proxy"
+          - "account"
+          - "custom"
+          - "alert"
+          - "input"
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout backend repo addonfactory-ucc-generator
+        with:
+            repository: splunk/addonfactory-ucc-generator
+            path: .
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.4.2
+      - run: poetry install
+      - name: Link chromedriver
+        # Use installed chromedriver https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
+        run: |
+          export PATH=$PATH:$CHROMEWEBDRIVER
+          chromedriver --version
+      - name: Download UI artifact from build job
+        uses: actions/download-artifact@v3
+        with:
+          name: splunk-ucc-ui
+      - run: |
+          ./get-ucc-ui.sh
+          tar -zxf /tmp/splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
+          poetry build
+      - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
+      - run: |
+          ./run_splunk.sh ${{ matrix.splunk.version }}
+          until curl -Lsk "https://localhost:8088/services/collector/health" &>/dev/null ; do echo -n "Waiting for HEC-" && sleep 5 ; done
+        timeout-minutes: 5
+      - run: poetry run pytest tests/ui -m "${{ matrix.test-mark }}" --headless --junitxml=test-results/junit.xml
+      - uses: actions/upload-artifact@v3
+        if: success() || failure()
+        with:
+          name: test-results-ui-${{ matrix.test-mark }}
+          path: test-results/*

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -126,10 +126,7 @@ jobs:
 
   test-ui:
     name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}
-    if: |
-      github.base_ref == 'main' ||
-      github.ref_name == 'main' ||
-      contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    if: contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
     runs-on: ubuntu-latest
     continue-on-error: true
     needs:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -126,7 +126,9 @@ jobs:
 
   test-ui:
     name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}
-    if: contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    if: |
+      github.base_ref == 'main' ||
+      github.ref_name == 'main'
     runs-on: ubuntu-latest
     continue-on-error: true
     needs:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -166,7 +166,8 @@ jobs:
         with:
           name: splunk-ucc-ui
       - run: |
-          tar -zxf /tmp/splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
+          ls -al
+          tar -zxf tmp/splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry build
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
       - run: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -166,8 +166,7 @@ jobs:
         with:
           name: splunk-ucc-ui
       - run: |
-          ls -al
-          tar -zxf tmp/splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
+          tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry build
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
       - run: |

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -166,7 +166,6 @@ jobs:
         with:
           name: splunk-ucc-ui
       - run: |
-          ./get-ucc-ui.sh
           tar -zxf /tmp/splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry build
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package


### PR DESCRIPTION
PR adds ability to run e2e tests from the [addonfactory-ucc-generator](https://github.com/splunk/addonfactory-ucc-generator) repository