### PR TITLE
feat: ADDON-65006 add group name to URL when redirecting with Menu

### DIFF
--- a/src/main/webapp/components/MenuInput.jsx
+++ b/src/main/webapp/components/MenuInput.jsx
@@ -19,8 +19,10 @@ const CustomSubTitle = styled.span`
     font-weight: 500;
 `;
 
+export const ROOT_GROUP_NAME = 'main_panel';
+
 function MenuInput({ handleRequestOpen }) {
-    const [activePanelId, setActivePanelId] = useState('main_panel');
+    const [activePanelId, setActivePanelId] = useState(ROOT_GROUP_NAME);
     const [slidingPanelsTransition, setSlidingPanelsTransition] = useState('forward');
     const [openDropDown, setOpenDropDown] = useState(false);
     const [isSubMenu, setIsSubMenu] = useState(true);
@@ -85,7 +87,7 @@ function MenuInput({ handleRequestOpen }) {
             <Menu.Item
                 icon={<ChevronLeft />}
                 onClick={() => {
-                    setActivePanelId('main_panel');
+                    setActivePanelId(ROOT_GROUP_NAME);
                     setSlidingPanelsTransition('backward');
                 }}
             >
@@ -99,14 +101,14 @@ function MenuInput({ handleRequestOpen }) {
         Object.keys(servicesGroup).map((groupsName) => (
             <SlidingPanels.Panel key={groupsName} panelId={groupsName}>
                 <Menu>
-                    {groupsName !== 'main_panel' && getBackButton()}
+                    {groupsName !== ROOT_GROUP_NAME && getBackButton()}
                     {getMenuItems(servicesGroup[groupsName], groupsName)}
                 </Menu>
             </SlidingPanels.Panel>
         ));
 
     const getInputMenu = useMemo(() => {
-        const servicesGroup = { main_panel: [] };
+        const servicesGroup = { [ROOT_GROUP_NAME]: [] };
         if (groupsMenu) {
             groupsMenu.forEach((group) => {
                 if (group?.groupServices) {
@@ -120,13 +122,13 @@ function MenuInput({ handleRequestOpen }) {
                                 ?.subTitle,
                         });
                     });
-                    servicesGroup.main_panel.push({
+                    servicesGroup[ROOT_GROUP_NAME].push({
                         name: group.groupName,
                         title: group.groupTitle,
                         hasSubmenu: true,
                     });
                 } else {
-                    servicesGroup.main_panel.push({
+                    servicesGroup[ROOT_GROUP_NAME].push({
                         name: group.groupName,
                         title: group.groupTitle,
                         subTitle: services.find((service) => service.name === group.groupName)
@@ -136,7 +138,7 @@ function MenuInput({ handleRequestOpen }) {
                 }
             });
         } else {
-            servicesGroup.main_panel = services.map((service) => ({
+            servicesGroup[ROOT_GROUP_NAME] = services.map((service) => ({
                 name: service.name,
                 title: service.title,
                 subTitle: service.subTitle,

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -119,7 +119,7 @@ function InputPage() {
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
             const selectedGroup = groupName && groupName !== ROOT_GROUP_NAME ? groupName : null;
-            const inputQueryValue = input || selectedGroup;
+            const inputQueryValue = input || selectedGroup || serviceName;
             if (inputQueryValue) {
                 query.set('input', inputQueryValue);
             } else {

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -12,7 +12,7 @@ import { TableContextProvider } from '../../context/TableContext';
 import { MODE_CREATE, MODE_CLONE, MODE_EDIT } from '../../constants/modes';
 import { PAGE_INPUT } from '../../constants/pages';
 import { STYLE_PAGE } from '../../constants/dialogStyles';
-import MenuInput from '../../components/MenuInput';
+import MenuInput, { ROOT_GROUP_NAME } from '../../components/MenuInput';
 import TableWrapper from '../../components/table/TableWrapper';
 import EntityModal from '../../components/EntityModal';
 import ErrorBoundary from '../../components/ErrorBoundary';
@@ -100,7 +100,7 @@ function InputPage() {
     };
 
     // handle modal/page open request on create/add entity button
-    const handleRequestOpen = ({ serviceName, groupName, input }) => {
+    const handleRequestOpen = ({ serviceName, groupName }) => {
         const service = services.find((x) => x.name === serviceName);
         const serviceTitle = service.title;
         const isInputPageStyle = service.style === STYLE_PAGE;
@@ -118,10 +118,10 @@ function InputPage() {
             // set query and push to navigate
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
-            if (input) {
-                query.set('input', input);
+            if (groupName && groupName !== ROOT_GROUP_NAME) {
+                query.set('group', groupName);
             } else {
-                query.delete('input');
+                query.delete('group');
             }
             navigate({ search: query.toString() });
         }
@@ -252,7 +252,7 @@ function InputPage() {
                                         page={PAGE_INPUT}
                                         serviceName={service.name}
                                         handleRequestModalOpen={() =>
-                                            handleRequestOpen(service.name)
+                                            handleRequestOpen({ serviceName: service.name })
                                         }
                                         handleOpenPageStyleDialog={handleOpenPageStyleDialog}
                                     />

--- a/src/main/webapp/pages/Input/InputPage.jsx
+++ b/src/main/webapp/pages/Input/InputPage.jsx
@@ -100,7 +100,7 @@ function InputPage() {
     };
 
     // handle modal/page open request on create/add entity button
-    const handleRequestOpen = ({ serviceName, groupName }) => {
+    const handleRequestOpen = ({ serviceName, groupName, input }) => {
         const service = services.find((x) => x.name === serviceName);
         const serviceTitle = service.title;
         const isInputPageStyle = service.style === STYLE_PAGE;
@@ -118,10 +118,12 @@ function InputPage() {
             // set query and push to navigate
             query.set('service', serviceName);
             query.set('action', MODE_CREATE);
-            if (groupName && groupName !== ROOT_GROUP_NAME) {
-                query.set('group', groupName);
+            const selectedGroup = groupName && groupName !== ROOT_GROUP_NAME ? groupName : null;
+            const inputQueryValue = input || selectedGroup;
+            if (inputQueryValue) {
+                query.set('input', inputQueryValue);
             } else {
-                query.delete('group');
+                query.delete('input');
             }
             navigate({ search: query.toString() });
         }

--- a/src/main/webapp/pages/Input/InputPage.test.tsx
+++ b/src/main/webapp/pages/Input/InputPage.test.tsx
@@ -19,7 +19,7 @@ beforeEach(() => {
     mockCustomMenuInstance = mockCustomMenu().mockCustomMenuInstance;
 });
 
-it('should redirect user on menu click', async () => {
+it('custom menu should redirect user on menu click', async () => {
     render(<InputPage />, { wrapper: BrowserRouter });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
@@ -40,6 +40,6 @@ it('should redirect user on menu click', async () => {
 
     // check that InputPage redirects to correct URL according to callback
     expect(mockNavigateFn).toHaveBeenCalledWith({
-        search: `service=${service}&action=${action}&input=${input}`,
+        search: `service=${service}&action=${action}`,
     });
 });

--- a/src/main/webapp/pages/Input/InputPage.test.tsx
+++ b/src/main/webapp/pages/Input/InputPage.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { render, screen, waitForElementToBeRemoved, act } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 
+import userEvent from '@testing-library/user-event';
 import InputPage from './InputPage';
 import { mockCustomMenu, MockCustomRenderable } from '../../tests/helpers';
 
@@ -41,5 +42,23 @@ it('custom menu should redirect user on menu click', async () => {
     // check that InputPage redirects to correct URL according to callback
     expect(mockNavigateFn).toHaveBeenCalledWith({
         search: `service=${service}&action=${action}&input=${input}`,
+    });
+});
+
+it('menu should redirect user on menu click', async () => {
+    render(<InputPage />, { wrapper: BrowserRouter });
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create New Input' }));
+    expect(mockNavigateFn).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Billing' }));
+    await userEvent.click(
+        screen.getByRole('menuitem', { name: 'Billing (Cost and Usage Report) (Recommended)' })
+    );
+
+    expect(mockNavigateFn).toHaveBeenCalledWith({
+        search: `service=aws_billing_cur&action=create&input=aws_billing_menu`,
     });
 });

--- a/src/main/webapp/pages/Input/InputPage.test.tsx
+++ b/src/main/webapp/pages/Input/InputPage.test.tsx
@@ -63,7 +63,7 @@ it('click on menu item inside group should add input query to URL', async () => 
     });
 });
 
-it('click on root menu item should not add input query to URL', async () => {
+it('click on root menu item should add input query to URL', async () => {
     render(<InputPage />, { wrapper: BrowserRouter });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
@@ -74,6 +74,6 @@ it('click on root menu item should not add input query to URL', async () => {
     await userEvent.click(screen.getByRole('menuitem', { name: 'CloudWatch' }));
 
     expect(mockNavigateFn).toHaveBeenCalledWith({
-        search: `service=aws_cloudwatch&action=create`,
+        search: `service=aws_cloudwatch&action=create&input=aws_cloudwatch`,
     });
 });

--- a/src/main/webapp/pages/Input/InputPage.test.tsx
+++ b/src/main/webapp/pages/Input/InputPage.test.tsx
@@ -45,7 +45,7 @@ it('custom menu should redirect user on menu click', async () => {
     });
 });
 
-it('menu should redirect user on menu click', async () => {
+it('click on menu item inside group should add input query to URL', async () => {
     render(<InputPage />, { wrapper: BrowserRouter });
 
     await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
@@ -60,5 +60,20 @@ it('menu should redirect user on menu click', async () => {
 
     expect(mockNavigateFn).toHaveBeenCalledWith({
         search: `service=aws_billing_cur&action=create&input=aws_billing_menu`,
+    });
+});
+
+it('click on root menu item should not add input query to URL', async () => {
+    render(<InputPage />, { wrapper: BrowserRouter });
+
+    await waitForElementToBeRemoved(() => screen.queryByTestId('wait-spinner'));
+
+    await userEvent.click(screen.getByRole('button', { name: 'Create New Input' }));
+    expect(mockNavigateFn).not.toHaveBeenCalled();
+
+    await userEvent.click(screen.getByRole('menuitem', { name: 'CloudWatch' }));
+
+    expect(mockNavigateFn).toHaveBeenCalledWith({
+        search: `service=aws_cloudwatch&action=create`,
     });
 });

--- a/src/main/webapp/pages/Input/InputPage.test.tsx
+++ b/src/main/webapp/pages/Input/InputPage.test.tsx
@@ -40,6 +40,6 @@ it('custom menu should redirect user on menu click', async () => {
 
     // check that InputPage redirects to correct URL according to callback
     expect(mockNavigateFn).toHaveBeenCalledWith({
-        search: `service=${service}&action=${action}`,
+        search: `service=${service}&action=${action}&input=${input}`,
     });
 });

--- a/src/main/webapp/util/__mocks__/mockUnifiedConfig.ts
+++ b/src/main/webapp/util/__mocks__/mockUnifiedConfig.ts
@@ -31,6 +31,17 @@ export const mockUnifiedConfig = {
                 },
                 actions: ['edit', 'delete', 'clone'],
             },
+            groupsMenu: [
+                {
+                    groupName: 'aws_billing_menu',
+                    groupTitle: 'Billing',
+                    groupServices: ['aws_billing_cur', 'aws_billing'],
+                },
+                {
+                    groupName: 'aws_cloudwatch',
+                    groupTitle: 'CloudWatch',
+                },
+            ],
             menu: {
                 src: 'CustomMenu',
                 type: 'external',
@@ -39,6 +50,7 @@ export const mockUnifiedConfig = {
                 {
                     name: 'aws_billing_cur',
                     title: 'Billing (Cost and Usage Report)',
+                    subTitle: '(Recommended)',
                     style: 'page',
                     hook: {
                         src: 'Hook',
@@ -86,9 +98,6 @@ export const mockUnifiedConfig = {
                             label: 'Name',
                             type: 'text',
                             required: true,
-                            options: {
-                                placeholder: 'Required',
-                            },
                             validators: [
                                 {
                                     type: 'regex',
@@ -157,9 +166,6 @@ export const mockUnifiedConfig = {
                             label: 'Name',
                             type: 'text',
                             required: true,
-                            options: {
-                                placeholder: 'Required',
-                            },
                             validators: [
                                 {
                                     type: 'regex',

--- a/src/main/webapp/util/__mocks__/mockUnifiedConfig.ts
+++ b/src/main/webapp/util/__mocks__/mockUnifiedConfig.ts
@@ -177,6 +177,55 @@ export const mockUnifiedConfig = {
                         },
                     ],
                 },
+                {
+                    name: 'aws_cloudwatch',
+                    title: 'CloudWatch',
+                    style: 'page',
+                    hook: {
+                        src: 'Hook',
+                        type: 'external',
+                    },
+                    restHandlerName: 'aws_cloudwatch_inputs_rh',
+                    groups: [
+                        {
+                            label: 'AWS Input Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: [
+                                'name',
+                                'aws_account',
+                                'aws_iam_role',
+                                'aws_region',
+                                'private_endpoint_enabled',
+                                'sts_private_endpoint_url',
+                                'monitoring_private_endpoint_url',
+                                'elb_private_endpoint_url',
+                                'ec2_private_endpoint_url',
+                                'autoscaling_private_endpoint_url',
+                                'lambda_private_endpoint_url',
+                                's3_private_endpoint_url',
+                                'metric_namespace',
+                            ],
+                        },
+                        {
+                            label: 'Splunk-related Configuration',
+                            options: {
+                                isExpandable: false,
+                            },
+                            fields: ['sourcetype', 'index'],
+                        },
+                        {
+                            label: 'Advanced Settings',
+                            options: {
+                                expand: false,
+                                isExpandable: true,
+                            },
+                            fields: ['period'],
+                        },
+                    ],
+                    entity: [],
+                },
             ],
         },
     },


### PR DESCRIPTION
[ADDON-65006](https://splunk.atlassian.net/browse/ADDON-65006)

The value of `input` is taken from `groupName` field of globalConfig (if present).

The menu itself (for reference):
<img width="238" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/0f5ccd85-fbe3-493d-9789-cfcde4c05860">

Click on _S3 Access Logs_ -> _SQS-Based S3_ opens the URL with populated `input` query: 
<img width="1340" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/7a6aa2ea-34a4-493c-843c-f4b76f47a2c3">


For a root-level menu item the `input` value is not populated:
<img width="1340" alt="image" src="https://github.com/splunk/addonfactory-ucc-base-ui/assets/142901247/a8ded5de-04c3-4024-834e-ab22a7728fdb">

the `input` value provided by custom component by calling `navigator` function takes precedence. 

Related PR: splunk/splunk-add-on-for-amazon-web-services#1053