### PR TITLE
feat: add meta.checkForUpdates field

### DIFF
--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -1098,6 +1098,10 @@
         "schemaVersion": {
           "type": "string",
           "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
+        },
+        "checkForUpdates": {
+          "type": "boolean",
+          "default": true
         }
       },
       "required": ["displayName", "name", "restRoot", "version"],


### PR DESCRIPTION
Adding this new field to account for new check from AppInspect which validates `app.conf -> package -> check_for_updates` field to be explicitly set. 

This new field in `meta` will allow us to configure it on UCC level. By default, it is true.