### PR TITLE
chore(schema.json): update JSON Schema spec version

### DIFF
--- a/src/main/webapp/schema/schema.json
+++ b/src/main/webapp/schema/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
   "definitions": {
     "AlertEntity": {
       "type": "object",


### PR DESCRIPTION
No schema changes required for this upgrade.

addonfactory-ucc-generator [uses jsonschema v.4.17.3](https://github.com/splunk/addonfactory-ucc-generator/blob/main/poetry.lock#L578) which has partial support of draft 2020-12. We don't use unsupported features, so we are good to upgrade.
By the way, the latest version has full support of 2020-12.